### PR TITLE
Add placeholder extraction scripts and golden vectors

### DIFF
--- a/contract/midi2.json
+++ b/contract/midi2.json
@@ -1,0 +1,4 @@
+{
+  "generatedAt": "2025-08-09T18:53:42.988Z",
+  "note": "TODO: replace with data extracted from Workbench runtime"
+}

--- a/scripts/export-checklist.ts
+++ b/scripts/export-checklist.ts
@@ -1,0 +1,14 @@
+/**
+ * Placeholder for Workbench compliance checklist export.
+ * The real implementation should connect to the Workbench
+ * and write reports/compliance/* based on runtime checks.
+ */
+
+async function main() {
+  console.log('TODO: implement export-checklist');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/extract.ts
+++ b/scripts/extract.ts
@@ -28,6 +28,29 @@ async function main() {
   );
 
   console.log('Wrote contract/midi2.json');
+
+  const vectorNames = [
+    'ump_channel_voice',
+    'ump_system',
+    'ump_utility_stream',
+    'ci_dialogues',
+    'profiles_pe',
+  ];
+
+  for (const name of vectorNames) {
+    const vector = [
+      {
+        note: `TODO: replace with ${name} data extracted from Workbench runtime`,
+      },
+    ];
+
+    await fs.writeFile(
+      path.join(vectorsDir, `${name}.json`),
+      JSON.stringify(vector, null, 2)
+    );
+  }
+
+  console.log('Wrote placeholder golden vectors');
 }
 
 main().catch((err) => {

--- a/scripts/headless-runner.ts
+++ b/scripts/headless-runner.ts
@@ -1,0 +1,14 @@
+/**
+ * Placeholder for a JSON-RPC headless Workbench runner.
+ * This script will eventually allow the generated Swift
+ * binaries to interact with the Workbench without a UI.
+ */
+
+async function main() {
+  console.log('TODO: implement headless-runner');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/vectors/golden/ci_dialogues.json
+++ b/vectors/golden/ci_dialogues.json
@@ -1,0 +1,5 @@
+[
+  {
+    "note": "TODO: replace with ci_dialogues data extracted from Workbench runtime"
+  }
+]

--- a/vectors/golden/profiles_pe.json
+++ b/vectors/golden/profiles_pe.json
@@ -1,0 +1,5 @@
+[
+  {
+    "note": "TODO: replace with profiles_pe data extracted from Workbench runtime"
+  }
+]

--- a/vectors/golden/ump_channel_voice.json
+++ b/vectors/golden/ump_channel_voice.json
@@ -1,0 +1,5 @@
+[
+  {
+    "note": "TODO: replace with ump_channel_voice data extracted from Workbench runtime"
+  }
+]

--- a/vectors/golden/ump_system.json
+++ b/vectors/golden/ump_system.json
@@ -1,0 +1,5 @@
+[
+  {
+    "note": "TODO: replace with ump_system data extracted from Workbench runtime"
+  }
+]

--- a/vectors/golden/ump_utility_stream.json
+++ b/vectors/golden/ump_utility_stream.json
@@ -1,0 +1,5 @@
+[
+  {
+    "note": "TODO: replace with ump_utility_stream data extracted from Workbench runtime"
+  }
+]


### PR DESCRIPTION
## Summary
- extend `scripts/extract.ts` to emit placeholder golden vector files alongside the contract
- add stub `export-checklist.ts` and `headless-runner.ts` scripts for future automation
- commit initial `contract/midi2.json` and placeholder golden vector JSONs

## Testing
- `yarn install` *(fails: electron, midi, usb modules failed to build)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68979800536c8333b23d38909916f62d