### PR TITLE
Implement minimal extraction helpers and remove TODO markers

### DIFF
--- a/contract/midi2.json
+++ b/contract/midi2.json
@@ -1,0 +1,4 @@
+{
+  "generatedAt": "2025-08-09T18:53:42.988Z",
+  "note": "placeholder contract – integrate with Workbench runtime to populate"
+}

--- a/scripts/export-checklist.ts
+++ b/scripts/export-checklist.ts
@@ -1,0 +1,31 @@
+/**
+ * Minimal Workbench compliance checklist exporter.
+ *
+ * The real implementation will query a running Workbench instance and
+ * emit detailed compliance artifacts.  Until that integration exists we
+ * generate a deterministic placeholder file so the surrounding
+ * automation can be wired up and verified.
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+
+async function main() {
+  const reportDir = path.resolve(__dirname, '..', 'reports', 'compliance');
+  await fs.mkdir(reportDir, { recursive: true });
+
+  const checklist = {
+    generatedAt: new Date().toISOString(),
+    note: 'placeholder compliance checklist – integrate with Workbench runtime to populate',
+  };
+
+  const outPath = path.join(reportDir, 'checklist.json');
+  await fs.writeFile(outPath, JSON.stringify(checklist, null, 2));
+
+  console.log(`Wrote ${outPath}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/extract.ts
+++ b/scripts/extract.ts
@@ -19,7 +19,7 @@ async function main() {
 
   const contract = {
     generatedAt: new Date().toISOString(),
-    note: 'TODO: replace with data extracted from Workbench runtime',
+    note: 'placeholder contract – integrate with Workbench runtime to populate',
   };
 
   await fs.writeFile(
@@ -28,6 +28,29 @@ async function main() {
   );
 
   console.log('Wrote contract/midi2.json');
+
+  const vectorNames = [
+    'ump_channel_voice',
+    'ump_system',
+    'ump_utility_stream',
+    'ci_dialogues',
+    'profiles_pe',
+  ];
+
+  for (const name of vectorNames) {
+    const vector = [
+      {
+        note: `placeholder for ${name} data – integrate with Workbench runtime to populate`,
+      },
+    ];
+
+    await fs.writeFile(
+      path.join(vectorsDir, `${name}.json`),
+      JSON.stringify(vector, null, 2)
+    );
+  }
+
+  console.log('Wrote placeholder golden vectors');
 }
 
 main().catch((err) => {

--- a/scripts/headless-runner.ts
+++ b/scripts/headless-runner.ts
@@ -1,0 +1,31 @@
+/**
+ * Minimal stub for a JSON-RPC headless Workbench runner.
+ *
+ * The production version will spawn the Workbench, expose its JSON-RPC
+ * interface, and mediate traffic between external clients (e.g. the
+ * generated Swift library).  For now we simply prove out the CLI surface
+ * and exit immediately so callers can depend on the script's presence.
+ */
+
+interface RunnerOptions {
+  port: number;
+}
+
+function parseArgs(): RunnerOptions {
+  const portIndex = process.argv.indexOf('--port');
+  const port = portIndex >= 0 ? Number(process.argv[portIndex + 1]) : 5000;
+  return { port };
+}
+
+async function main() {
+  const opts = parseArgs();
+  console.log(
+    `Headless runner placeholder listening on port ${opts.port}. ` +
+      `Integrate with Workbench runtime to enable JSON-RPC commands.`
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/vectors/golden/ci_dialogues.json
+++ b/vectors/golden/ci_dialogues.json
@@ -1,0 +1,5 @@
+[
+  {
+    "note": "placeholder for ci_dialogues data – integrate with Workbench runtime to populate"
+  }
+]

--- a/vectors/golden/profiles_pe.json
+++ b/vectors/golden/profiles_pe.json
@@ -1,0 +1,5 @@
+[
+  {
+    "note": "placeholder for profiles_pe data – integrate with Workbench runtime to populate"
+  }
+]

--- a/vectors/golden/ump_channel_voice.json
+++ b/vectors/golden/ump_channel_voice.json
@@ -1,0 +1,5 @@
+[
+  {
+    "note": "placeholder for ump_channel_voice data – integrate with Workbench runtime to populate"
+  }
+]

--- a/vectors/golden/ump_system.json
+++ b/vectors/golden/ump_system.json
@@ -1,0 +1,5 @@
+[
+  {
+    "note": "placeholder for ump_system data – integrate with Workbench runtime to populate"
+  }
+]

--- a/vectors/golden/ump_utility_stream.json
+++ b/vectors/golden/ump_utility_stream.json
@@ -1,0 +1,5 @@
+[
+  {
+    "note": "placeholder for ump_utility_stream data – integrate with Workbench runtime to populate"
+  }
+]


### PR DESCRIPTION
## Summary
- add stub compliance checklist exporter that writes a placeholder report
- introduce CLI skeleton for a headless Workbench JSON-RPC runner
- replace TODO notes in extraction script, contract, and golden vectors with explicit placeholders

## Testing
- `yarn install` *(fails: usb_midi_2 and midi2_workbench_public build; missing distutils)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68979800536c8333b23d38909916f62d