### PR TITLE
Remove duplicate property-exchange schemas

### DIFF
--- a/swift/Midi2Swift/Sources/Profiles/PropertyExchangeCatalog.swift
+++ b/swift/Midi2Swift/Sources/Profiles/PropertyExchangeCatalog.swift
@@ -2,80 +2,44 @@ import Foundation
 
 public enum PropertyExchangeResource: String, CaseIterable {
     case ResourceList
-    case schema
     case DeviceInfo
-    case schema
     case ChannelList
-    case schema
     case JSONSchema
-    case schema
     case ModeList
-    case schema
     case CurrentMode
-    case schema
     case ProgramList
-    case schema
     case ExternalSync
-    case schema
     case LocalOn
-    case schema
     case ChannelMode
-    case schema
     case BasicChannelRx
-    case schema
     case BasicChannelTx
-    case schema
     case State
-    case schema
     case StateList
-    case schema
     case MaxSysex8Streams
-    case schema
     case AllCtrlList
-    case schema
     case ChCtrlList
-    case schema
     case CtrlMapList
-    case schema
 }
 
 public enum PropertyExchangeCatalog {
     public static let all: [String] = [
         "ResourceList",
-        "schema",
         "DeviceInfo",
-        "schema",
         "ChannelList",
-        "schema",
         "JSONSchema",
-        "schema",
         "ModeList",
-        "schema",
         "CurrentMode",
-        "schema",
         "ProgramList",
-        "schema",
         "ExternalSync",
-        "schema",
         "LocalOn",
-        "schema",
         "ChannelMode",
-        "schema",
         "BasicChannelRx",
-        "schema",
         "BasicChannelTx",
-        "schema",
         "State",
-        "schema",
         "StateList",
-        "schema",
         "MaxSysex8Streams",
-        "schema",
         "AllCtrlList",
-        "schema",
         "ChCtrlList",
-        "schema",
-        "CtrlMapList",
-        "schema"
+        "CtrlMapList"
     ]
 }


### PR DESCRIPTION
## Summary
- ensure PropertyExchange resource catalog only lists unique resources

## Testing
- `swift build` *(fails: type 'SysEx7Complete' does not conform to protocol 'Equatable')*
- `swift test` *(fails: fatalError)*

------
https://chatgpt.com/codex/tasks/task_b_68981df9117483339c396564492c2ef3