### PR TITLE
Add commit metadata and enum extraction to static contract

### DIFF
--- a/contract/midi2.json
+++ b/contract/midi2.json
@@ -1,2241 +1,145 @@
 {
   "$schema": "https://fountain.example/schemas/midi2-contract.schema.json",
   "meta": {
-    "workbench_commit": "unknown",
-    "generated_at": "2025-08-10T03:56:27.571Z"
+    "workbench_commit": "1d3fbb510190603b2f214b29deae4ba49a11449a",
+    "generated_at": "2025-08-10T06:09:35.142Z"
   },
-  "enums": {},
+  "enums": {
+    "MessageType": {
+      "type": "uint4",
+      "values": {
+        "DeltaClockstamp": 0,
+        "ActiveSensing": 1,
+        "ChannelPressureMessage": 2,
+        "CompleteSystemExclusiveMessageinOnePacket": 3,
+        "AssignableControllerNRPNMessages": 4,
+        "CompleteSystemExclusive8MessageinOnePacket": 5,
+        "FlexDataMessages0x0": 13,
+        "EndofFileMessage": 15
+      }
+    },
+    "Status10": {
+      "type": "uint10",
+      "values": {
+        "GetMIDIEndpointInfo": 0,
+        "MIDIEndpointInfoNotify": 1,
+        "MIDIEndpointDeviceInfoNotify": 2,
+        "MIDIEndpointNameNotify": 3,
+        "MIDIEndpointProductInstanceIdNotify": 4,
+        "StreamConfigurationRequest": 5,
+        "StreamConfigurationNotify": 6,
+        "GetFunctionBlockInfo": 16,
+        "FunctionBlockInfoNotification": 17,
+        "FunctionBlockNameNotification": 18,
+        "StartofSequenceMessage": 32,
+        "EndofFileMessage": 33
+      }
+    },
+    "StatusByte": {
+      "type": "uint8",
+      "values": {
+        "MIDITimeCode": 241,
+        "SongPositionPointer": 242,
+        "SongSelect": 243,
+        "TuneRequest": 246,
+        "TimingClock": 248,
+        "Start": 250,
+        "Continue": 251,
+        "Stop": 252,
+        "ActiveSensing": 254,
+        "Reset": 255
+      }
+    },
+    "StatusCode": {
+      "type": "uint4",
+      "values": {
+        "NOOP": 0,
+        "JRClock": 1,
+        "JRTimestamp": 2,
+        "DeltaClockstampTicksPerQuarterNote": 3,
+        "DeltaClockstamp": 4
+      }
+    },
+    "StatusLSB": {
+      "type": "uint8",
+      "values": {
+        "FlexDataMessages0x1FlexDataMessages0x0": 0,
+        "FlexDataMessages0x1FlexDataMessages0x1": 1,
+        "FlexDataMessages0x1FlexDataMessages0x2": 2,
+        "FlexDataMessages0x1FlexDataMessages0x3": 3,
+        "FlexDataMessages0x1FlexDataMessages0x4": 4,
+        "FlexDataMessages0x1FlexDataMessages0x5": 5,
+        "FlexDataMessages0x1FlexDataMessages0x6": 6,
+        "FlexDataMessages0x1FlexDataMessages0x7": 7,
+        "FlexDataMessages0x1FlexDataMessages0x8": 8,
+        "FlexDataMessages0x1FlexDataMessages0x9": 9,
+        "FlexDataMessages0x1FlexDataMessages0xA": 10,
+        "FlexDataMessages0x1FlexDataMessages0xB": 11,
+        "FlexDataMessages0x1FlexDataMessages0xC": 12
+      }
+    },
+    "StatusMSB": {
+      "type": "uint8",
+      "values": {
+        "FlexDataMessages0x0": 0,
+        "FlexDataMessages0x1": 1,
+        "FlexDataMessages0x2": 2,
+        "FlexDataMessages0x3": 3,
+        "FlexDataMessages0x4": 4,
+        "FlexDataMessages0x5": 5,
+        "FlexDataMessages0x6": 6,
+        "FlexDataMessages0x7": 7,
+        "FlexDataMessages0x8": 8,
+        "FlexDataMessages0x9": 9,
+        "FlexDataMessages0xA": 10,
+        "FlexDataMessages0xB": 11,
+        "FlexDataMessages0xC": 12
+      }
+    },
+    "StatusNibble": {
+      "type": "uint4",
+      "values": {
+        "RegisteredPerNoteController": 0,
+        "AssignablePerNoteController": 1,
+        "RegisteredControllerRPN": 2,
+        "AssignableControllerNRPNMessages": 3,
+        "RelativeRegisteredControllerRPN": 4,
+        "RelativeAssignableControllerNRPN": 5,
+        "PerNotePitchBend": 6,
+        "NoteOff": 8,
+        "NoteOn": 9,
+        "PolyPressure": 10,
+        "ControlChangeMessage": 11,
+        "ProgramChangeMessage": 12,
+        "ChannelPressureMessage": 13,
+        "PitchBend": 14,
+        "PerNoteManagementMessage": 15
+      }
+    },
+    "Sysex8Form": {
+      "type": "uint4",
+      "values": {
+        "CompleteSystemExclusive8MessageinOnePacket": 0,
+        "SystemExclusive8StartPacket": 1,
+        "SystemExclusive8ContinuePacket": 2,
+        "SystemExclusiveEndPacket": 3,
+        "MixedDataSetHeader": 8,
+        "MixedDataSetPayload": 9
+      }
+    },
+    "SysexForm": {
+      "type": "uint4",
+      "values": {
+        "CompleteSystemExclusiveMessageinOnePacket": 0,
+        "SystemExclusiveStartPacket": 1,
+        "SystemExclusiveContinuePacket": 2,
+        "SystemExclusiveEndPacket": 3
+      }
+    }
+  },
   "messages": [
     {
-      "name": "UtilityMessages.NOOP",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 0
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusCode",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 0
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "UtilityMessages.JRClock",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 0
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusCode",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 1
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "UtilityMessages.JRTimestamp",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 0
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusCode",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 2
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "UtilityMessages.DeltaClockstampTicksPerQuarterNote",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 0
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusCode",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 3
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "UtilityMessages.DeltaClockstamp",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 0
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusCode",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 4
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SystemRealTimeandSystemCommonMessages.MIDITimeCode",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 1
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusByte",
-          "bitOffset": 8,
-          "bitWidth": 8,
-          "value": 241
-        },
-        {
-          "name": "nnndddd",
-          "bitOffset": 17,
-          "bitWidth": 7
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SystemRealTimeandSystemCommonMessages.SongPositionPointer",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 1
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusByte",
-          "bitOffset": 8,
-          "bitWidth": 8,
-          "value": 242
-        },
-        {
-          "name": "lllllll",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "mmmmmmm",
-          "bitOffset": 24,
-          "bitWidth": 8
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SystemRealTimeandSystemCommonMessages.SongSelect",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 1
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusByte",
-          "bitOffset": 8,
-          "bitWidth": 8,
-          "value": 243
-        },
-        {
-          "name": "sssssss",
-          "bitOffset": 17,
-          "bitWidth": 7
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SystemRealTimeandSystemCommonMessages.TuneRequest",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 1
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusByte",
-          "bitOffset": 8,
-          "bitWidth": 8,
-          "value": 246
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SystemRealTimeandSystemCommonMessages.TimingClock",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 1
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusByte",
-          "bitOffset": 8,
-          "bitWidth": 8,
-          "value": 248
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SystemRealTimeandSystemCommonMessages.Start",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 1
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusByte",
-          "bitOffset": 8,
-          "bitWidth": 8,
-          "value": 250
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SystemRealTimeandSystemCommonMessages.Continue",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 1
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusByte",
-          "bitOffset": 8,
-          "bitWidth": 8,
-          "value": 251
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SystemRealTimeandSystemCommonMessages.Stop",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 1
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusByte",
-          "bitOffset": 8,
-          "bitWidth": 8,
-          "value": 252
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SystemRealTimeandSystemCommonMessages.ActiveSensing",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 1
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusByte",
-          "bitOffset": 8,
-          "bitWidth": 8,
-          "value": 254
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SystemRealTimeandSystemCommonMessages.Reset",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 1
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusByte",
-          "bitOffset": 8,
-          "bitWidth": 8,
-          "value": 255
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI10ChannelVoiceMessages.NoteOff",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 2
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 8
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "noteNumber",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "velocity",
-          "bitOffset": 25,
-          "bitWidth": 7
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI10ChannelVoiceMessages.NoteOn",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 2
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 9
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "noteNumber",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "velocity",
-          "bitOffset": 25,
-          "bitWidth": 7
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI10ChannelVoiceMessages.PolyPressure",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 2
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 10
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "noteNumber",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "Pressure",
-          "bitOffset": 25,
-          "bitWidth": 7
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI10ChannelVoiceMessages.ControlChangeMessage",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 2
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 11
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "index",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "value",
-          "bitOffset": 25,
-          "bitWidth": 7
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI10ChannelVoiceMessages.ProgramChangeMessage",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 2
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 12
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "program",
-          "bitOffset": 17,
-          "bitWidth": 7
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI10ChannelVoiceMessages.ChannelPressureMessage",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 2
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 13
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "Pressure",
-          "bitOffset": 17,
-          "bitWidth": 7
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI10ChannelVoiceMessages.PitchBend",
-      "container": "UMP32",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 2
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 14
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "LSBdata",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "MSBdata",
-          "bitOffset": 25,
-          "bitWidth": 7
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 32"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SysEx.CompleteSystemExclusiveMessageinOnePacket",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 3
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "sysexForm",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 0
-        },
-        {
-          "name": "byteCount",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "Byte1",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte2",
-          "bitOffset": 25,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte3",
-          "bitOffset": 33,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte4",
-          "bitOffset": 41,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte5",
-          "bitOffset": 49,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte6",
-          "bitOffset": 57,
-          "bitWidth": 7
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SysEx.SystemExclusiveStartPacket",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 3
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "sysexForm",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 1
-        },
-        {
-          "name": "byteCount",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "Byte1",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte2",
-          "bitOffset": 25,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte3",
-          "bitOffset": 33,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte4",
-          "bitOffset": 41,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte5",
-          "bitOffset": 49,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte6",
-          "bitOffset": 57,
-          "bitWidth": 7
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SysEx.SystemExclusiveContinuePacket",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 3
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "sysexForm",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 2
-        },
-        {
-          "name": "byteCount",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "Byte1",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte2",
-          "bitOffset": 25,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte3",
-          "bitOffset": 33,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte4",
-          "bitOffset": 41,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte5",
-          "bitOffset": 49,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte6",
-          "bitOffset": 57,
-          "bitWidth": 7
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SysEx.SystemExclusiveEndPacket",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 3
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "sysexForm",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 3
-        },
-        {
-          "name": "byteCount",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "Byte1",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte2",
-          "bitOffset": 25,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte3",
-          "bitOffset": 33,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte4",
-          "bitOffset": 41,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte5",
-          "bitOffset": 49,
-          "bitWidth": 7
-        },
-        {
-          "name": "Byte6",
-          "bitOffset": 57,
-          "bitWidth": 7
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI20ChannelVoiceMessages.NoteOff",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 4
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 8
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "noteNumber",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "attributeType",
-          "bitOffset": 25,
-          "bitWidth": 7
-        },
-        {
-          "name": "velocity",
-          "bitOffset": 32,
-          "bitWidth": 16
-        },
-        {
-          "name": "attribute",
-          "bitOffset": 48,
-          "bitWidth": 16
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI20ChannelVoiceMessages.NoteOn",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 4
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 9
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "noteNumber",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "attributeType",
-          "bitOffset": 25,
-          "bitWidth": 7
-        },
-        {
-          "name": "velocity",
-          "bitOffset": 32,
-          "bitWidth": 16
-        },
-        {
-          "name": "attribute",
-          "bitOffset": 48,
-          "bitWidth": 16
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI20ChannelVoiceMessages.PolyPressure",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 4
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 10
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "noteNumber",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "Pressure",
-          "bitOffset": 32,
-          "bitWidth": 32
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI20ChannelVoiceMessages.ControlChangeMessage",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 4
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 11
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "index",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "value",
-          "bitOffset": 32,
-          "bitWidth": 32
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI20ChannelVoiceMessages.RegisteredControllerRPN",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 4
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 2
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "Bank",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "index",
-          "bitOffset": 25,
-          "bitWidth": 7
-        },
-        {
-          "name": "value",
-          "bitOffset": 32,
-          "bitWidth": 32
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI20ChannelVoiceMessages.AssignableControllerNRPNMessages",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 4
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 3
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "Bank",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "index",
-          "bitOffset": 25,
-          "bitWidth": 7
-        },
-        {
-          "name": "value",
-          "bitOffset": 32,
-          "bitWidth": 32
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI20ChannelVoiceMessages.RelativeRegisteredControllerRPN",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 4
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 4
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "Bank",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "index",
-          "bitOffset": 25,
-          "bitWidth": 7
-        },
-        {
-          "name": "value",
-          "bitOffset": 32,
-          "bitWidth": 32
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI20ChannelVoiceMessages.RelativeAssignableControllerNRPN",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 4
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 5
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "Bank",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "index",
-          "bitOffset": 25,
-          "bitWidth": 7
-        },
-        {
-          "name": "value",
-          "bitOffset": 32,
-          "bitWidth": 32
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI20ChannelVoiceMessages.ProgramChangeMessage",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 4
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 12
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "bankValid",
-          "bitOffset": 31,
-          "bitWidth": 1
-        },
-        {
-          "name": "program",
-          "bitOffset": 33,
-          "bitWidth": 7
-        },
-        {
-          "name": "BankMSB",
-          "bitOffset": 49,
-          "bitWidth": 7
-        },
-        {
-          "name": "BankLSB",
-          "bitOffset": 57,
-          "bitWidth": 7
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI20ChannelVoiceMessages.ChannelPressureMessage",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 4
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 13
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "Pressure",
-          "bitOffset": 32,
-          "bitWidth": 32
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI20ChannelVoiceMessages.PitchBend",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 4
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 14
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "pitch",
-          "bitOffset": 32,
-          "bitWidth": 32
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI20ChannelVoiceMessages.PerNotePitchBend",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 4
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 6
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "noteNumber",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "pitch",
-          "bitOffset": 32,
-          "bitWidth": 32
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI20ChannelVoiceMessages.AssignablePerNoteController",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 4
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 1
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "noteNumber",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "index",
-          "bitOffset": 24,
-          "bitWidth": 8
-        },
-        {
-          "name": "value",
-          "bitOffset": 32,
-          "bitWidth": 32
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI20ChannelVoiceMessages.RegisteredPerNoteController",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 4
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 0
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "noteNumber",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "index",
-          "bitOffset": 24,
-          "bitWidth": 8
-        },
-        {
-          "name": "value",
-          "bitOffset": 32,
-          "bitWidth": 32
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDI20ChannelVoiceMessages.PerNoteManagementMessage",
-      "container": "UMP64",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 4
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "statusNibble",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 15
-        },
-        {
-          "name": "channel",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "noteNumber",
-          "bitOffset": 17,
-          "bitWidth": 7
-        },
-        {
-          "name": "DetachPerNotecontrollersfrompreviouslyreceivedNotes",
-          "bitOffset": 30,
-          "bitWidth": 1
-        },
-        {
-          "name": "ResetSetPerNotecontrollerstodefaultvalues",
-          "bitOffset": 31,
-          "bitWidth": 1
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 64"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SysEx8andMDS.CompleteSystemExclusive8MessageinOnePacket",
-      "container": "UMP128",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 5
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "sysex8Form",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 0
-        },
-        {
-          "name": "byteCount",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "streamid",
-          "bitOffset": 16,
-          "bitWidth": 8
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 128"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SysEx8andMDS.SystemExclusive8StartPacket",
-      "container": "UMP128",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 5
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "sysex8Form",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 1
-        },
-        {
-          "name": "byteCount",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "streamid",
-          "bitOffset": 16,
-          "bitWidth": 8
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 128"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SysEx8andMDS.SystemExclusive8ContinuePacket",
-      "container": "UMP128",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 5
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "sysex8Form",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 2
-        },
-        {
-          "name": "byteCount",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "streamid",
-          "bitOffset": 16,
-          "bitWidth": 8
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 128"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SysEx8andMDS.SystemExclusiveEndPacket",
-      "container": "UMP128",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 5
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "sysex8Form",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 3
-        },
-        {
-          "name": "byteCount",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "streamid",
-          "bitOffset": 16,
-          "bitWidth": 8
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 128"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SysEx8andMDS.MixedDataSetHeader",
-      "container": "UMP128",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 5
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "sysex8Form",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 8
-        },
-        {
-          "name": "byteCount",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "mdsId",
-          "bitOffset": 16,
-          "bitWidth": 8
-        },
-        {
-          "name": "numberofvalidbytesinthismessagechunk",
-          "bitOffset": 24,
-          "bitWidth": 8
-        },
-        {
-          "name": "numberofchunksinmixeddataset",
-          "bitOffset": 32,
-          "bitWidth": 16
-        },
-        {
-          "name": "numberofthischunk",
-          "bitOffset": 48,
-          "bitWidth": 16
-        },
-        {
-          "name": "manufacturerid",
-          "bitOffset": 64,
-          "bitWidth": 16
-        },
-        {
-          "name": "deviceid",
-          "bitOffset": 80,
-          "bitWidth": 16
-        },
-        {
-          "name": "subid1",
-          "bitOffset": 96,
-          "bitWidth": 16
-        },
-        {
-          "name": "subid2",
-          "bitOffset": 112,
-          "bitWidth": 16
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 128"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "SysEx8andMDS.MixedDataSetPayload",
-      "container": "UMP128",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 5
-        },
-        {
-          "name": "group",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "sysex8Form",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "value": 9
-        },
-        {
-          "name": "byteCount",
-          "bitOffset": 12,
-          "bitWidth": 4
-        },
-        {
-          "name": "mdsId",
-          "bitOffset": 16,
-          "bitWidth": 8
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 128"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x0",
+      "name": "FlexDataMessages.FlexDataMessages0x0",
       "container": "UMP128",
       "fields": [
         {
@@ -2276,12 +180,6 @@
           "bitOffset": 16,
           "bitWidth": 8,
           "value": 0
-        },
-        {
-          "name": "statusLSB",
-          "bitOffset": 24,
-          "bitWidth": 8,
-          "value": 0
         }
       ],
       "invariants": [
@@ -2293,7 +191,7 @@
       }
     },
     {
-      "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x1",
+      "name": "FlexDataMessages.FlexDataMessages0x0",
       "container": "UMP128",
       "fields": [
         {
@@ -2334,196 +232,6 @@
           "bitOffset": 16,
           "bitWidth": 8,
           "value": 0
-        },
-        {
-          "name": "statusLSB",
-          "bitOffset": 24,
-          "bitWidth": 8,
-          "value": 1
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 128"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "FlexDataMessages.SubdivisionClicks1SubdivisionClicks1",
-      "container": "UMP128",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 13
-        },
-        {
-          "name": "channel",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "group",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "form",
-          "bitOffset": 12,
-          "bitWidth": 2,
-          "range": [
-            0,
-            3
-          ]
-        },
-        {
-          "name": "statusMSB",
-          "bitOffset": 16,
-          "bitWidth": 8,
-          "value": 0
-        },
-        {
-          "name": "statusLSB",
-          "bitOffset": 24,
-          "bitWidth": 8,
-          "value": 2
-        },
-        {
-          "name": "SubdivisionClicks1",
-          "bitOffset": 64,
-          "bitWidth": 8
-        },
-        {
-          "name": "SubdivisionClicks2",
-          "bitOffset": 72,
-          "bitWidth": 8
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 128"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x5",
-      "container": "UMP128",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 13
-        },
-        {
-          "name": "channel",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "group",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "form",
-          "bitOffset": 12,
-          "bitWidth": 2,
-          "range": [
-            0,
-            3
-          ]
-        },
-        {
-          "name": "statusMSB",
-          "bitOffset": 16,
-          "bitWidth": 8,
-          "value": 0
-        },
-        {
-          "name": "statusLSB",
-          "bitOffset": 24,
-          "bitWidth": 8,
-          "value": 5
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 128"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x6",
-      "container": "UMP128",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 13
-        },
-        {
-          "name": "channel",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "group",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "form",
-          "bitOffset": 12,
-          "bitWidth": 2,
-          "range": [
-            0,
-            3
-          ]
-        },
-        {
-          "name": "statusMSB",
-          "bitOffset": 16,
-          "bitWidth": 8,
-          "value": 0
-        },
-        {
-          "name": "statusLSB",
-          "bitOffset": 24,
-          "bitWidth": 8,
-          "value": 6
         }
       ],
       "invariants": [
@@ -2639,7 +347,7 @@
       }
     },
     {
-      "name": "FlexDataMessages.SubdivisionClicks1",
+      "name": "FlexDataMessages.FlexDataMessages0x1",
       "container": "UMP128",
       "fields": [
         {
@@ -2679,17 +387,7 @@
           "name": "statusMSB",
           "bitOffset": 16,
           "bitWidth": 8,
-          "value": 2
-        },
-        {
-          "name": "SubdivisionClicks1",
-          "bitOffset": 64,
-          "bitWidth": 8
-        },
-        {
-          "name": "SubdivisionClicks2",
-          "bitOffset": 72,
-          "bitWidth": 8
+          "value": 1
         }
       ],
       "invariants": [
@@ -2701,7 +399,7 @@
       }
     },
     {
-      "name": "FlexDataMessages.FlexDataMessages0x5",
+      "name": "FlexDataMessages.FlexDataMessages0x1",
       "container": "UMP128",
       "fields": [
         {
@@ -2741,59 +439,7 @@
           "name": "statusMSB",
           "bitOffset": 16,
           "bitWidth": 8,
-          "value": 5
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 128"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "FlexDataMessages.FlexDataMessages0x6",
-      "container": "UMP128",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 13
-        },
-        {
-          "name": "channel",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "group",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "form",
-          "bitOffset": 12,
-          "bitWidth": 2,
-          "range": [
-            0,
-            3
-          ]
-        },
-        {
-          "name": "statusMSB",
-          "bitOffset": 16,
-          "bitWidth": 8,
-          "value": 6
+          "value": 1
         }
       ],
       "invariants": [
@@ -3559,7 +1205,7 @@
       }
     },
     {
-      "name": "FlexDataMessages.FlexDataMessages0x0",
+      "name": "FlexDataMessages.FlexDataMessages0x2",
       "container": "UMP128",
       "fields": [
         {
@@ -3599,59 +1245,7 @@
           "name": "statusMSB",
           "bitOffset": 16,
           "bitWidth": 8,
-          "value": 0
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 128"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "FlexDataMessages.FlexDataMessages0x1",
-      "container": "UMP128",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 13
-        },
-        {
-          "name": "channel",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "group",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "form",
-          "bitOffset": 12,
-          "bitWidth": 2,
-          "range": [
-            0,
-            3
-          ]
-        },
-        {
-          "name": "statusMSB",
-          "bitOffset": 16,
-          "bitWidth": 8,
-          "value": 1
+          "value": 2
         }
       ],
       "invariants": [
@@ -3704,6 +1298,348 @@
           "bitOffset": 16,
           "bitWidth": 8,
           "value": 2
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x0",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 13
+        },
+        {
+          "name": "channel",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "group",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "form",
+          "bitOffset": 12,
+          "bitWidth": 2,
+          "range": [
+            0,
+            3
+          ]
+        },
+        {
+          "name": "statusMSB",
+          "bitOffset": 16,
+          "bitWidth": 8,
+          "value": 2
+        },
+        {
+          "name": "statusLSB",
+          "bitOffset": 24,
+          "bitWidth": 8,
+          "value": 0
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x1",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 13
+        },
+        {
+          "name": "channel",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "group",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "form",
+          "bitOffset": 12,
+          "bitWidth": 2,
+          "range": [
+            0,
+            3
+          ]
+        },
+        {
+          "name": "statusMSB",
+          "bitOffset": 16,
+          "bitWidth": 8,
+          "value": 2
+        },
+        {
+          "name": "statusLSB",
+          "bitOffset": 24,
+          "bitWidth": 8,
+          "value": 1
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x2",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 13
+        },
+        {
+          "name": "channel",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "group",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "form",
+          "bitOffset": 12,
+          "bitWidth": 2,
+          "range": [
+            0,
+            3
+          ]
+        },
+        {
+          "name": "statusMSB",
+          "bitOffset": 16,
+          "bitWidth": 8,
+          "value": 2
+        },
+        {
+          "name": "statusLSB",
+          "bitOffset": 24,
+          "bitWidth": 8,
+          "value": 2
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x3",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 13
+        },
+        {
+          "name": "channel",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "group",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "form",
+          "bitOffset": 12,
+          "bitWidth": 2,
+          "range": [
+            0,
+            3
+          ]
+        },
+        {
+          "name": "statusMSB",
+          "bitOffset": 16,
+          "bitWidth": 8,
+          "value": 2
+        },
+        {
+          "name": "statusLSB",
+          "bitOffset": 24,
+          "bitWidth": 8,
+          "value": 3
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x4",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 13
+        },
+        {
+          "name": "channel",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "group",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "form",
+          "bitOffset": 12,
+          "bitWidth": 2,
+          "range": [
+            0,
+            3
+          ]
+        },
+        {
+          "name": "statusMSB",
+          "bitOffset": 16,
+          "bitWidth": 8,
+          "value": 2
+        },
+        {
+          "name": "statusLSB",
+          "bitOffset": 24,
+          "bitWidth": 8,
+          "value": 4
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "FlexDataMessages.FlexDataMessages0x3",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 13
+        },
+        {
+          "name": "channel",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "group",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "form",
+          "bitOffset": 12,
+          "bitWidth": 2,
+          "range": [
+            0,
+            3
+          ]
+        },
+        {
+          "name": "statusMSB",
+          "bitOffset": 16,
+          "bitWidth": 8,
+          "value": 3
         }
       ],
       "invariants": [
@@ -3819,6 +1755,58 @@
       }
     },
     {
+      "name": "FlexDataMessages.FlexDataMessages0x4",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 13
+        },
+        {
+          "name": "channel",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "group",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "form",
+          "bitOffset": 12,
+          "bitWidth": 2,
+          "range": [
+            0,
+            3
+          ]
+        },
+        {
+          "name": "statusMSB",
+          "bitOffset": 16,
+          "bitWidth": 8,
+          "value": 4
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
       "name": "FlexDataMessages.FlexDataMessages0x5",
       "container": "UMP128",
       "fields": [
@@ -3860,6 +1848,110 @@
           "bitOffset": 16,
           "bitWidth": 8,
           "value": 5
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "FlexDataMessages.FlexDataMessages0x5",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 13
+        },
+        {
+          "name": "channel",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "group",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "form",
+          "bitOffset": 12,
+          "bitWidth": 2,
+          "range": [
+            0,
+            3
+          ]
+        },
+        {
+          "name": "statusMSB",
+          "bitOffset": 16,
+          "bitWidth": 8,
+          "value": 5
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "FlexDataMessages.FlexDataMessages0x6",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 13
+        },
+        {
+          "name": "channel",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "group",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "form",
+          "bitOffset": 12,
+          "bitWidth": 2,
+          "range": [
+            0,
+            3
+          ]
+        },
+        {
+          "name": "statusMSB",
+          "bitOffset": 16,
+          "bitWidth": 8,
+          "value": 6
         }
       ],
       "invariants": [
@@ -4235,7 +2327,7 @@
       }
     },
     {
-      "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x0",
+      "name": "FlexDataMessages.SubdivisionClicks1",
       "container": "UMP128",
       "fields": [
         {
@@ -4278,10 +2370,14 @@
           "value": 2
         },
         {
-          "name": "statusLSB",
-          "bitOffset": 24,
-          "bitWidth": 8,
-          "value": 0
+          "name": "SubdivisionClicks1",
+          "bitOffset": 64,
+          "bitWidth": 8
+        },
+        {
+          "name": "SubdivisionClicks2",
+          "bitOffset": 72,
+          "bitWidth": 8
         }
       ],
       "invariants": [
@@ -4293,239 +2389,7 @@
       }
     },
     {
-      "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x1",
-      "container": "UMP128",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 13
-        },
-        {
-          "name": "channel",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "group",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "form",
-          "bitOffset": 12,
-          "bitWidth": 2,
-          "range": [
-            0,
-            3
-          ]
-        },
-        {
-          "name": "statusMSB",
-          "bitOffset": 16,
-          "bitWidth": 8,
-          "value": 2
-        },
-        {
-          "name": "statusLSB",
-          "bitOffset": 24,
-          "bitWidth": 8,
-          "value": 1
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 128"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x2",
-      "container": "UMP128",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 13
-        },
-        {
-          "name": "channel",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "group",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "form",
-          "bitOffset": 12,
-          "bitWidth": 2,
-          "range": [
-            0,
-            3
-          ]
-        },
-        {
-          "name": "statusMSB",
-          "bitOffset": 16,
-          "bitWidth": 8,
-          "value": 2
-        },
-        {
-          "name": "statusLSB",
-          "bitOffset": 24,
-          "bitWidth": 8,
-          "value": 2
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 128"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x3",
-      "container": "UMP128",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 13
-        },
-        {
-          "name": "channel",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "group",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "form",
-          "bitOffset": 12,
-          "bitWidth": 2,
-          "range": [
-            0,
-            3
-          ]
-        },
-        {
-          "name": "statusMSB",
-          "bitOffset": 16,
-          "bitWidth": 8,
-          "value": 2
-        },
-        {
-          "name": "statusLSB",
-          "bitOffset": 24,
-          "bitWidth": 8,
-          "value": 3
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 128"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x4",
-      "container": "UMP128",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 13
-        },
-        {
-          "name": "channel",
-          "bitOffset": 4,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "group",
-          "bitOffset": 8,
-          "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
-        },
-        {
-          "name": "form",
-          "bitOffset": 12,
-          "bitWidth": 2,
-          "range": [
-            0,
-            3
-          ]
-        },
-        {
-          "name": "statusMSB",
-          "bitOffset": 16,
-          "bitWidth": 8,
-          "value": 2
-        },
-        {
-          "name": "statusLSB",
-          "bitOffset": 24,
-          "bitWidth": 8,
-          "value": 4
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 128"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "FlexDataMessages.FlexDataMessages0x0",
+      "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x0",
       "container": "UMP128",
       "fields": [
         {
@@ -4566,6 +2430,12 @@
           "bitOffset": 16,
           "bitWidth": 8,
           "value": 0
+        },
+        {
+          "name": "statusLSB",
+          "bitOffset": 24,
+          "bitWidth": 8,
+          "value": 0
         }
       ],
       "invariants": [
@@ -4577,7 +2447,7 @@
       }
     },
     {
-      "name": "FlexDataMessages.FlexDataMessages0x1",
+      "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x1",
       "container": "UMP128",
       "fields": [
         {
@@ -4616,6 +2486,12 @@
         {
           "name": "statusMSB",
           "bitOffset": 16,
+          "bitWidth": 8,
+          "value": 0
+        },
+        {
+          "name": "statusLSB",
+          "bitOffset": 24,
           "bitWidth": 8,
           "value": 1
         }
@@ -4629,7 +2505,7 @@
       }
     },
     {
-      "name": "FlexDataMessages.FlexDataMessages0x2",
+      "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x5",
       "container": "UMP128",
       "fields": [
         {
@@ -4668,8 +2544,140 @@
         {
           "name": "statusMSB",
           "bitOffset": 16,
+          "bitWidth": 8,
+          "value": 0
+        },
+        {
+          "name": "statusLSB",
+          "bitOffset": 24,
+          "bitWidth": 8,
+          "value": 5
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x6",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 13
+        },
+        {
+          "name": "channel",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "group",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "form",
+          "bitOffset": 12,
+          "bitWidth": 2,
+          "range": [
+            0,
+            3
+          ]
+        },
+        {
+          "name": "statusMSB",
+          "bitOffset": 16,
+          "bitWidth": 8,
+          "value": 0
+        },
+        {
+          "name": "statusLSB",
+          "bitOffset": 24,
+          "bitWidth": 8,
+          "value": 6
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "FlexDataMessages.SubdivisionClicks1SubdivisionClicks1",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 13
+        },
+        {
+          "name": "channel",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "group",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "form",
+          "bitOffset": 12,
+          "bitWidth": 2,
+          "range": [
+            0,
+            3
+          ]
+        },
+        {
+          "name": "statusMSB",
+          "bitOffset": 16,
+          "bitWidth": 8,
+          "value": 0
+        },
+        {
+          "name": "statusLSB",
+          "bitOffset": 24,
           "bitWidth": 8,
           "value": 2
+        },
+        {
+          "name": "SubdivisionClicks1",
+          "bitOffset": 64,
+          "bitWidth": 8
+        },
+        {
+          "name": "SubdivisionClicks2",
+          "bitOffset": 72,
+          "bitWidth": 8
         }
       ],
       "invariants": [
@@ -4681,17 +2689,17 @@
       }
     },
     {
-      "name": "FlexDataMessages.FlexDataMessages0x3",
-      "container": "UMP128",
+      "name": "MIDI10ChannelVoiceMessages.ChannelPressureMessage",
+      "container": "UMP32",
       "fields": [
         {
           "name": "messageType",
           "bitOffset": 0,
           "bitWidth": 4,
-          "value": 13
+          "value": 2
         },
         {
-          "name": "channel",
+          "name": "group",
           "bitOffset": 4,
           "bitWidth": 4,
           "range": [
@@ -4700,32 +2708,24 @@
           ]
         },
         {
-          "name": "group",
+          "name": "statusNibble",
           "bitOffset": 8,
           "bitWidth": 4,
-          "range": [
-            0,
-            15
-          ]
+          "value": 13
         },
         {
-          "name": "form",
+          "name": "channel",
           "bitOffset": 12,
-          "bitWidth": 2,
-          "range": [
-            0,
-            3
-          ]
+          "bitWidth": 4
         },
         {
-          "name": "statusMSB",
-          "bitOffset": 16,
-          "bitWidth": 8,
-          "value": 3
+          "name": "Pressure",
+          "bitOffset": 17,
+          "bitWidth": 7
         }
       ],
       "invariants": [
-        "bits_sum <= 128"
+        "bits_sum <= 32"
       ],
       "provenance": {
         "file": "libs/messageTypes.js",
@@ -4733,17 +2733,17 @@
       }
     },
     {
-      "name": "FlexDataMessages.FlexDataMessages0x4",
-      "container": "UMP128",
+      "name": "MIDI10ChannelVoiceMessages.ControlChangeMessage",
+      "container": "UMP32",
       "fields": [
         {
           "name": "messageType",
           "bitOffset": 0,
           "bitWidth": 4,
-          "value": 13
+          "value": 2
         },
         {
-          "name": "channel",
+          "name": "group",
           "bitOffset": 4,
           "bitWidth": 4,
           "range": [
@@ -4752,8 +2752,48 @@
           ]
         },
         {
-          "name": "group",
+          "name": "statusNibble",
           "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 11
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "index",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "value",
+          "bitOffset": 25,
+          "bitWidth": 7
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI10ChannelVoiceMessages.NoteOff",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 2
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
           "bitWidth": 4,
           "range": [
             0,
@@ -4761,19 +2801,1272 @@
           ]
         },
         {
-          "name": "form",
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 8
+        },
+        {
+          "name": "channel",
           "bitOffset": 12,
-          "bitWidth": 2,
+          "bitWidth": 4
+        },
+        {
+          "name": "noteNumber",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "velocity",
+          "bitOffset": 25,
+          "bitWidth": 7
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI10ChannelVoiceMessages.NoteOn",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 2
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
           "range": [
             0,
-            3
+            15
           ]
         },
         {
-          "name": "statusMSB",
-          "bitOffset": 16,
-          "bitWidth": 8,
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 9
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "noteNumber",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "velocity",
+          "bitOffset": 25,
+          "bitWidth": 7
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI10ChannelVoiceMessages.PitchBend",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 2
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 14
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "LSBdata",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "MSBdata",
+          "bitOffset": 25,
+          "bitWidth": 7
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI10ChannelVoiceMessages.PolyPressure",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 2
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 10
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "noteNumber",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "Pressure",
+          "bitOffset": 25,
+          "bitWidth": 7
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI10ChannelVoiceMessages.ProgramChangeMessage",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 2
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 12
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "program",
+          "bitOffset": 17,
+          "bitWidth": 7
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI20ChannelVoiceMessages.AssignableControllerNRPNMessages",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
           "value": 4
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 3
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "Bank",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "index",
+          "bitOffset": 25,
+          "bitWidth": 7
+        },
+        {
+          "name": "value",
+          "bitOffset": 32,
+          "bitWidth": 32
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI20ChannelVoiceMessages.AssignablePerNoteController",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 4
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 1
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "noteNumber",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "index",
+          "bitOffset": 24,
+          "bitWidth": 8
+        },
+        {
+          "name": "value",
+          "bitOffset": 32,
+          "bitWidth": 32
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI20ChannelVoiceMessages.ChannelPressureMessage",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 4
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 13
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "Pressure",
+          "bitOffset": 32,
+          "bitWidth": 32
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI20ChannelVoiceMessages.ControlChangeMessage",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 4
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 11
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "index",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "value",
+          "bitOffset": 32,
+          "bitWidth": 32
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI20ChannelVoiceMessages.NoteOff",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 4
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 8
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "noteNumber",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "attributeType",
+          "bitOffset": 25,
+          "bitWidth": 7
+        },
+        {
+          "name": "velocity",
+          "bitOffset": 32,
+          "bitWidth": 16
+        },
+        {
+          "name": "attribute",
+          "bitOffset": 48,
+          "bitWidth": 16
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI20ChannelVoiceMessages.NoteOn",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 4
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 9
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "noteNumber",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "attributeType",
+          "bitOffset": 25,
+          "bitWidth": 7
+        },
+        {
+          "name": "velocity",
+          "bitOffset": 32,
+          "bitWidth": 16
+        },
+        {
+          "name": "attribute",
+          "bitOffset": 48,
+          "bitWidth": 16
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI20ChannelVoiceMessages.PerNoteManagementMessage",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 4
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 15
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "noteNumber",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "DetachPerNotecontrollersfrompreviouslyreceivedNotes",
+          "bitOffset": 30,
+          "bitWidth": 1
+        },
+        {
+          "name": "ResetSetPerNotecontrollerstodefaultvalues",
+          "bitOffset": 31,
+          "bitWidth": 1
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI20ChannelVoiceMessages.PerNotePitchBend",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 4
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 6
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "noteNumber",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "pitch",
+          "bitOffset": 32,
+          "bitWidth": 32
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI20ChannelVoiceMessages.PitchBend",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 4
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 14
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "pitch",
+          "bitOffset": 32,
+          "bitWidth": 32
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI20ChannelVoiceMessages.PolyPressure",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 4
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 10
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "noteNumber",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "Pressure",
+          "bitOffset": 32,
+          "bitWidth": 32
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI20ChannelVoiceMessages.ProgramChangeMessage",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 4
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 12
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "bankValid",
+          "bitOffset": 31,
+          "bitWidth": 1
+        },
+        {
+          "name": "program",
+          "bitOffset": 33,
+          "bitWidth": 7
+        },
+        {
+          "name": "BankMSB",
+          "bitOffset": 49,
+          "bitWidth": 7
+        },
+        {
+          "name": "BankLSB",
+          "bitOffset": 57,
+          "bitWidth": 7
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI20ChannelVoiceMessages.RegisteredControllerRPN",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 4
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 2
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "Bank",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "index",
+          "bitOffset": 25,
+          "bitWidth": 7
+        },
+        {
+          "name": "value",
+          "bitOffset": 32,
+          "bitWidth": 32
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI20ChannelVoiceMessages.RegisteredPerNoteController",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 4
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 0
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "noteNumber",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "index",
+          "bitOffset": 24,
+          "bitWidth": 8
+        },
+        {
+          "name": "value",
+          "bitOffset": 32,
+          "bitWidth": 32
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI20ChannelVoiceMessages.RelativeAssignableControllerNRPN",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 4
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 5
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "Bank",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "index",
+          "bitOffset": 25,
+          "bitWidth": 7
+        },
+        {
+          "name": "value",
+          "bitOffset": 32,
+          "bitWidth": 32
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDI20ChannelVoiceMessages.RelativeRegisteredControllerRPN",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 4
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusNibble",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 4
+        },
+        {
+          "name": "channel",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "Bank",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "index",
+          "bitOffset": 25,
+          "bitWidth": 7
+        },
+        {
+          "name": "value",
+          "bitOffset": 32,
+          "bitWidth": 32
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDIEndpoint.EndofFileMessage",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 15
+        },
+        {
+          "name": "form",
+          "bitOffset": 4,
+          "bitWidth": 2,
+          "range": [
+            0,
+            3
+          ]
+        },
+        {
+          "name": "status10",
+          "bitOffset": 6,
+          "bitWidth": 10,
+          "value": 33
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDIEndpoint.FunctionBlockInfoNotification",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 15
+        },
+        {
+          "name": "form",
+          "bitOffset": 4,
+          "bitWidth": 2,
+          "range": [
+            0,
+            3
+          ]
+        },
+        {
+          "name": "status10",
+          "bitOffset": 6,
+          "bitWidth": 10,
+          "value": 17
+        },
+        {
+          "name": "Active",
+          "bitOffset": 16,
+          "bitWidth": 1
+        },
+        {
+          "name": "FunctionBlock",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "UIHint",
+          "bitOffset": 26,
+          "bitWidth": 2
+        },
+        {
+          "name": "IsMIDI10",
+          "bitOffset": 28,
+          "bitWidth": 2
+        },
+        {
+          "name": "Direction",
+          "bitOffset": 30,
+          "bitWidth": 2
+        },
+        {
+          "name": "FirstGroup",
+          "bitOffset": 32,
+          "bitWidth": 8
+        },
+        {
+          "name": "GroupLength",
+          "bitOffset": 40,
+          "bitWidth": 8
+        },
+        {
+          "name": "MIDICISupport",
+          "bitOffset": 49,
+          "bitWidth": 7
+        },
+        {
+          "name": "MaxSysExStreams",
+          "bitOffset": 56,
+          "bitWidth": 8
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDIEndpoint.FunctionBlockNameNotification",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 15
+        },
+        {
+          "name": "form",
+          "bitOffset": 4,
+          "bitWidth": 2,
+          "range": [
+            0,
+            3
+          ]
+        },
+        {
+          "name": "status10",
+          "bitOffset": 6,
+          "bitWidth": 10,
+          "value": 18
+        },
+        {
+          "name": "FunctionBlock",
+          "bitOffset": 16,
+          "bitWidth": 8
+        },
+        {
+          "name": "Byte1",
+          "bitOffset": 24,
+          "bitWidth": 8
+        },
+        {
+          "name": "Byte2",
+          "bitOffset": 32,
+          "bitWidth": 8
+        },
+        {
+          "name": "Byte3",
+          "bitOffset": 40,
+          "bitWidth": 8
+        },
+        {
+          "name": "Byte4",
+          "bitOffset": 48,
+          "bitWidth": 8
+        },
+        {
+          "name": "Byte5",
+          "bitOffset": 56,
+          "bitWidth": 8
+        },
+        {
+          "name": "Byte6",
+          "bitOffset": 64,
+          "bitWidth": 8
+        },
+        {
+          "name": "Byte7",
+          "bitOffset": 72,
+          "bitWidth": 8
+        },
+        {
+          "name": "Byte8",
+          "bitOffset": 80,
+          "bitWidth": 8
+        },
+        {
+          "name": "Byte9",
+          "bitOffset": 88,
+          "bitWidth": 8
+        },
+        {
+          "name": "Byte10",
+          "bitOffset": 96,
+          "bitWidth": 8
+        },
+        {
+          "name": "Byte11",
+          "bitOffset": 104,
+          "bitWidth": 8
+        },
+        {
+          "name": "Byte12",
+          "bitOffset": 112,
+          "bitWidth": 8
+        },
+        {
+          "name": "Byte13",
+          "bitOffset": 120,
+          "bitWidth": 8
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDIEndpoint.GetFunctionBlockInfo",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 15
+        },
+        {
+          "name": "form",
+          "bitOffset": 4,
+          "bitWidth": 2,
+          "range": [
+            0,
+            3
+          ]
+        },
+        {
+          "name": "status10",
+          "bitOffset": 6,
+          "bitWidth": 10,
+          "value": 16
+        },
+        {
+          "name": "FunctionBlock",
+          "bitOffset": 16,
+          "bitWidth": 8
+        },
+        {
+          "name": "RequestingaFunctionBlockNameNotification",
+          "bitOffset": 30,
+          "bitWidth": 1
+        },
+        {
+          "name": "RequestingaFunctionBlockInfoNotification",
+          "bitOffset": 31,
+          "bitWidth": 1
         }
       ],
       "invariants": [
@@ -4818,60 +4111,6 @@
           "name": "UMPVersionMinor",
           "bitOffset": 24,
           "bitWidth": 8
-        }
-      ],
-      "invariants": [
-        "bits_sum <= 128"
-      ],
-      "provenance": {
-        "file": "libs/messageTypes.js",
-        "line": 68
-      }
-    },
-    {
-      "name": "MIDIEndpoint.MIDIEndpointInfoNotify",
-      "container": "UMP128",
-      "fields": [
-        {
-          "name": "messageType",
-          "bitOffset": 0,
-          "bitWidth": 4,
-          "value": 15
-        },
-        {
-          "name": "form",
-          "bitOffset": 4,
-          "bitWidth": 2,
-          "range": [
-            0,
-            3
-          ]
-        },
-        {
-          "name": "status10",
-          "bitOffset": 6,
-          "bitWidth": 10,
-          "value": 1
-        },
-        {
-          "name": "UMPVersionMajor",
-          "bitOffset": 16,
-          "bitWidth": 8
-        },
-        {
-          "name": "UMPVersionMinor",
-          "bitOffset": 24,
-          "bitWidth": 8
-        },
-        {
-          "name": "StaticFunctionBlocks",
-          "bitOffset": 32,
-          "bitWidth": 1
-        },
-        {
-          "name": "NumberofFunctionBlocks",
-          "bitOffset": 33,
-          "bitWidth": 7
         }
       ],
       "invariants": [
@@ -4960,6 +4199,60 @@
         {
           "name": "SoftwareRevisionLevel4",
           "bitOffset": 121,
+          "bitWidth": 7
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "MIDIEndpoint.MIDIEndpointInfoNotify",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 15
+        },
+        {
+          "name": "form",
+          "bitOffset": 4,
+          "bitWidth": 2,
+          "range": [
+            0,
+            3
+          ]
+        },
+        {
+          "name": "status10",
+          "bitOffset": 6,
+          "bitWidth": 10,
+          "value": 1
+        },
+        {
+          "name": "UMPVersionMajor",
+          "bitOffset": 16,
+          "bitWidth": 8
+        },
+        {
+          "name": "UMPVersionMinor",
+          "bitOffset": 24,
+          "bitWidth": 8
+        },
+        {
+          "name": "StaticFunctionBlocks",
+          "bitOffset": 32,
+          "bitWidth": 1
+        },
+        {
+          "name": "NumberofFunctionBlocks",
+          "bitOffset": 33,
           "bitWidth": 7
         }
       ],
@@ -5180,7 +4473,7 @@
       }
     },
     {
-      "name": "MIDIEndpoint.StreamConfigurationRequest",
+      "name": "MIDIEndpoint.StartofSequenceMessage",
       "container": "UMP128",
       "fields": [
         {
@@ -5202,12 +4495,7 @@
           "name": "status10",
           "bitOffset": 6,
           "bitWidth": 10,
-          "value": 5
-        },
-        {
-          "name": "Protocol",
-          "bitOffset": 16,
-          "bitWidth": 8
+          "value": 32
         }
       ],
       "invariants": [
@@ -5258,7 +4546,7 @@
       }
     },
     {
-      "name": "MIDIEndpoint.GetFunctionBlockInfo",
+      "name": "MIDIEndpoint.StreamConfigurationRequest",
       "container": "UMP128",
       "fields": [
         {
@@ -5280,22 +4568,12 @@
           "name": "status10",
           "bitOffset": 6,
           "bitWidth": 10,
-          "value": 16
+          "value": 5
         },
         {
-          "name": "FunctionBlock",
+          "name": "Protocol",
           "bitOffset": 16,
           "bitWidth": 8
-        },
-        {
-          "name": "RequestingaFunctionBlockNameNotification",
-          "bitOffset": 30,
-          "bitWidth": 1
-        },
-        {
-          "name": "RequestingaFunctionBlockInfoNotification",
-          "bitOffset": 31,
-          "bitWidth": 1
         }
       ],
       "invariants": [
@@ -5307,73 +4585,314 @@
       }
     },
     {
-      "name": "MIDIEndpoint.FunctionBlockInfoNotification",
-      "container": "UMP128",
+      "name": "SysEx.CompleteSystemExclusiveMessageinOnePacket",
+      "container": "UMP64",
       "fields": [
         {
           "name": "messageType",
           "bitOffset": 0,
           "bitWidth": 4,
-          "value": 15
+          "value": 3
         },
         {
-          "name": "form",
+          "name": "group",
           "bitOffset": 4,
-          "bitWidth": 2,
+          "bitWidth": 4,
           "range": [
             0,
-            3
+            15
           ]
         },
         {
-          "name": "status10",
-          "bitOffset": 6,
-          "bitWidth": 10,
-          "value": 17
+          "name": "sysexForm",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 0
         },
         {
-          "name": "Active",
-          "bitOffset": 16,
-          "bitWidth": 1
+          "name": "byteCount",
+          "bitOffset": 12,
+          "bitWidth": 4
         },
         {
-          "name": "FunctionBlock",
+          "name": "Byte1",
           "bitOffset": 17,
           "bitWidth": 7
         },
         {
-          "name": "UIHint",
-          "bitOffset": 26,
-          "bitWidth": 2
+          "name": "Byte2",
+          "bitOffset": 25,
+          "bitWidth": 7
         },
         {
-          "name": "IsMIDI10",
-          "bitOffset": 28,
-          "bitWidth": 2
+          "name": "Byte3",
+          "bitOffset": 33,
+          "bitWidth": 7
         },
         {
-          "name": "Direction",
-          "bitOffset": 30,
-          "bitWidth": 2
+          "name": "Byte4",
+          "bitOffset": 41,
+          "bitWidth": 7
         },
         {
-          "name": "FirstGroup",
-          "bitOffset": 32,
-          "bitWidth": 8
-        },
-        {
-          "name": "GroupLength",
-          "bitOffset": 40,
-          "bitWidth": 8
-        },
-        {
-          "name": "MIDICISupport",
+          "name": "Byte5",
           "bitOffset": 49,
           "bitWidth": 7
         },
         {
-          "name": "MaxSysExStreams",
-          "bitOffset": 56,
+          "name": "Byte6",
+          "bitOffset": 57,
+          "bitWidth": 7
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "SysEx.SystemExclusiveContinuePacket",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 3
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "sysexForm",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 2
+        },
+        {
+          "name": "byteCount",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "Byte1",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "Byte2",
+          "bitOffset": 25,
+          "bitWidth": 7
+        },
+        {
+          "name": "Byte3",
+          "bitOffset": 33,
+          "bitWidth": 7
+        },
+        {
+          "name": "Byte4",
+          "bitOffset": 41,
+          "bitWidth": 7
+        },
+        {
+          "name": "Byte5",
+          "bitOffset": 49,
+          "bitWidth": 7
+        },
+        {
+          "name": "Byte6",
+          "bitOffset": 57,
+          "bitWidth": 7
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "SysEx.SystemExclusiveEndPacket",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 3
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "sysexForm",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 3
+        },
+        {
+          "name": "byteCount",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "Byte1",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "Byte2",
+          "bitOffset": 25,
+          "bitWidth": 7
+        },
+        {
+          "name": "Byte3",
+          "bitOffset": 33,
+          "bitWidth": 7
+        },
+        {
+          "name": "Byte4",
+          "bitOffset": 41,
+          "bitWidth": 7
+        },
+        {
+          "name": "Byte5",
+          "bitOffset": 49,
+          "bitWidth": 7
+        },
+        {
+          "name": "Byte6",
+          "bitOffset": 57,
+          "bitWidth": 7
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "SysEx.SystemExclusiveStartPacket",
+      "container": "UMP64",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 3
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "sysexForm",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 1
+        },
+        {
+          "name": "byteCount",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "Byte1",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "Byte2",
+          "bitOffset": 25,
+          "bitWidth": 7
+        },
+        {
+          "name": "Byte3",
+          "bitOffset": 33,
+          "bitWidth": 7
+        },
+        {
+          "name": "Byte4",
+          "bitOffset": 41,
+          "bitWidth": 7
+        },
+        {
+          "name": "Byte5",
+          "bitOffset": 49,
+          "bitWidth": 7
+        },
+        {
+          "name": "Byte6",
+          "bitOffset": 57,
+          "bitWidth": 7
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 64"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "SysEx8andMDS.CompleteSystemExclusive8MessageinOnePacket",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 5
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "sysex8Form",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 0
+        },
+        {
+          "name": "byteCount",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "streamid",
+          "bitOffset": 16,
           "bitWidth": 8
         }
       ],
@@ -5386,98 +4905,117 @@
       }
     },
     {
-      "name": "MIDIEndpoint.FunctionBlockNameNotification",
+      "name": "SysEx8andMDS.MixedDataSetHeader",
       "container": "UMP128",
       "fields": [
         {
           "name": "messageType",
           "bitOffset": 0,
           "bitWidth": 4,
-          "value": 15
+          "value": 5
         },
         {
-          "name": "form",
+          "name": "group",
           "bitOffset": 4,
-          "bitWidth": 2,
+          "bitWidth": 4,
           "range": [
             0,
-            3
+            15
           ]
         },
         {
-          "name": "status10",
-          "bitOffset": 6,
-          "bitWidth": 10,
-          "value": 18
+          "name": "sysex8Form",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 8
         },
         {
-          "name": "FunctionBlock",
+          "name": "byteCount",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "mdsId",
           "bitOffset": 16,
           "bitWidth": 8
         },
         {
-          "name": "Byte1",
+          "name": "numberofvalidbytesinthismessagechunk",
           "bitOffset": 24,
           "bitWidth": 8
         },
         {
-          "name": "Byte2",
+          "name": "numberofchunksinmixeddataset",
           "bitOffset": 32,
-          "bitWidth": 8
+          "bitWidth": 16
         },
         {
-          "name": "Byte3",
-          "bitOffset": 40,
-          "bitWidth": 8
-        },
-        {
-          "name": "Byte4",
+          "name": "numberofthischunk",
           "bitOffset": 48,
-          "bitWidth": 8
+          "bitWidth": 16
         },
         {
-          "name": "Byte5",
-          "bitOffset": 56,
-          "bitWidth": 8
-        },
-        {
-          "name": "Byte6",
+          "name": "manufacturerid",
           "bitOffset": 64,
-          "bitWidth": 8
+          "bitWidth": 16
         },
         {
-          "name": "Byte7",
-          "bitOffset": 72,
-          "bitWidth": 8
-        },
-        {
-          "name": "Byte8",
+          "name": "deviceid",
           "bitOffset": 80,
-          "bitWidth": 8
+          "bitWidth": 16
         },
         {
-          "name": "Byte9",
-          "bitOffset": 88,
-          "bitWidth": 8
-        },
-        {
-          "name": "Byte10",
+          "name": "subid1",
           "bitOffset": 96,
-          "bitWidth": 8
+          "bitWidth": 16
         },
         {
-          "name": "Byte11",
-          "bitOffset": 104,
-          "bitWidth": 8
-        },
-        {
-          "name": "Byte12",
+          "name": "subid2",
           "bitOffset": 112,
-          "bitWidth": 8
+          "bitWidth": 16
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "SysEx8andMDS.MixedDataSetPayload",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 5
         },
         {
-          "name": "Byte13",
-          "bitOffset": 120,
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "sysex8Form",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 9
+        },
+        {
+          "name": "byteCount",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "mdsId",
+          "bitOffset": 16,
           "bitWidth": 8
         }
       ],
@@ -5490,29 +5028,39 @@
       }
     },
     {
-      "name": "MIDIEndpoint.StartofSequenceMessage",
+      "name": "SysEx8andMDS.SystemExclusive8ContinuePacket",
       "container": "UMP128",
       "fields": [
         {
           "name": "messageType",
           "bitOffset": 0,
           "bitWidth": 4,
-          "value": 15
+          "value": 5
         },
         {
-          "name": "form",
+          "name": "group",
           "bitOffset": 4,
-          "bitWidth": 2,
+          "bitWidth": 4,
           "range": [
             0,
-            3
+            15
           ]
         },
         {
-          "name": "status10",
-          "bitOffset": 6,
-          "bitWidth": 10,
-          "value": 32
+          "name": "sysex8Form",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 2
+        },
+        {
+          "name": "byteCount",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "streamid",
+          "bitOffset": 16,
+          "bitWidth": 8
         }
       ],
       "invariants": [
@@ -5524,33 +5072,617 @@
       }
     },
     {
-      "name": "MIDIEndpoint.EndofFileMessage",
+      "name": "SysEx8andMDS.SystemExclusive8StartPacket",
       "container": "UMP128",
       "fields": [
         {
           "name": "messageType",
           "bitOffset": 0,
           "bitWidth": 4,
-          "value": 15
+          "value": 5
         },
         {
-          "name": "form",
+          "name": "group",
           "bitOffset": 4,
-          "bitWidth": 2,
+          "bitWidth": 4,
           "range": [
             0,
-            3
+            15
           ]
         },
         {
-          "name": "status10",
-          "bitOffset": 6,
-          "bitWidth": 10,
-          "value": 33
+          "name": "sysex8Form",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 1
+        },
+        {
+          "name": "byteCount",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "streamid",
+          "bitOffset": 16,
+          "bitWidth": 8
         }
       ],
       "invariants": [
         "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "SysEx8andMDS.SystemExclusiveEndPacket",
+      "container": "UMP128",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 5
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "sysex8Form",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 3
+        },
+        {
+          "name": "byteCount",
+          "bitOffset": 12,
+          "bitWidth": 4
+        },
+        {
+          "name": "streamid",
+          "bitOffset": 16,
+          "bitWidth": 8
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 128"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "SystemRealTimeandSystemCommonMessages.ActiveSensing",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 1
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusByte",
+          "bitOffset": 8,
+          "bitWidth": 8,
+          "value": 254
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "SystemRealTimeandSystemCommonMessages.Continue",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 1
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusByte",
+          "bitOffset": 8,
+          "bitWidth": 8,
+          "value": 251
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "SystemRealTimeandSystemCommonMessages.MIDITimeCode",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 1
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusByte",
+          "bitOffset": 8,
+          "bitWidth": 8,
+          "value": 241
+        },
+        {
+          "name": "nnndddd",
+          "bitOffset": 17,
+          "bitWidth": 7
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "SystemRealTimeandSystemCommonMessages.Reset",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 1
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusByte",
+          "bitOffset": 8,
+          "bitWidth": 8,
+          "value": 255
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "SystemRealTimeandSystemCommonMessages.SongPositionPointer",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 1
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusByte",
+          "bitOffset": 8,
+          "bitWidth": 8,
+          "value": 242
+        },
+        {
+          "name": "lllllll",
+          "bitOffset": 17,
+          "bitWidth": 7
+        },
+        {
+          "name": "mmmmmmm",
+          "bitOffset": 24,
+          "bitWidth": 8
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "SystemRealTimeandSystemCommonMessages.SongSelect",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 1
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusByte",
+          "bitOffset": 8,
+          "bitWidth": 8,
+          "value": 243
+        },
+        {
+          "name": "sssssss",
+          "bitOffset": 17,
+          "bitWidth": 7
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "SystemRealTimeandSystemCommonMessages.Start",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 1
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusByte",
+          "bitOffset": 8,
+          "bitWidth": 8,
+          "value": 250
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "SystemRealTimeandSystemCommonMessages.Stop",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 1
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusByte",
+          "bitOffset": 8,
+          "bitWidth": 8,
+          "value": 252
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "SystemRealTimeandSystemCommonMessages.TimingClock",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 1
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusByte",
+          "bitOffset": 8,
+          "bitWidth": 8,
+          "value": 248
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "SystemRealTimeandSystemCommonMessages.TuneRequest",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 1
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusByte",
+          "bitOffset": 8,
+          "bitWidth": 8,
+          "value": 246
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "UtilityMessages.DeltaClockstamp",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 0
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusCode",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 4
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "UtilityMessages.DeltaClockstampTicksPerQuarterNote",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 0
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusCode",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 3
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "UtilityMessages.JRClock",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 0
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusCode",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 1
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "UtilityMessages.JRTimestamp",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 0
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusCode",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 2
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
+      ],
+      "provenance": {
+        "file": "libs/messageTypes.js",
+        "line": 68
+      }
+    },
+    {
+      "name": "UtilityMessages.NOOP",
+      "container": "UMP32",
+      "fields": [
+        {
+          "name": "messageType",
+          "bitOffset": 0,
+          "bitWidth": 4,
+          "value": 0
+        },
+        {
+          "name": "group",
+          "bitOffset": 4,
+          "bitWidth": 4,
+          "range": [
+            0,
+            15
+          ]
+        },
+        {
+          "name": "statusCode",
+          "bitOffset": 8,
+          "bitWidth": 4,
+          "value": 0
+        }
+      ],
+      "invariants": [
+        "bits_sum <= 32"
       ],
       "provenance": {
         "file": "libs/messageTypes.js",
@@ -5559,6 +5691,48 @@
     }
   ],
   "state_machines": [
+    {
+      "name": "MIDI-CI.ConfirmationNewProtocolEstablishedMessage",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.DiscoveryReply",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
     {
       "name": "MIDI-CI.DiscoveryRequest",
       "states": [
@@ -5593,152 +5767,6 @@
           "from": "RequestSent",
           "on": "Error",
           "to": "Failed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.DiscoveryReply",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.InquiryEndpointInformation",
-      "states": [
-        "Idle",
-        "RequestSent",
-        "Completed",
-        "Failed"
-      ],
-      "events": [
-        "Start",
-        "Reply",
-        "Timeout",
-        "Error"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Start",
-          "to": "RequestSent"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Reply",
-          "to": "Completed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Timeout",
-          "to": "Failed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Error",
-          "to": "Failed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ReplytoEndpointInformation",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.MIDICIACK",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.InvalidateMUID",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.MIDICINAK",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
         }
       ],
       "provenance": {
@@ -5788,7 +5816,805 @@
       }
     },
     {
+      "name": "MIDI-CI.InquiryEndpointInformation",
+      "states": [
+        "Idle",
+        "RequestSent",
+        "Completed",
+        "Failed"
+      ],
+      "events": [
+        "Start",
+        "Reply",
+        "Timeout",
+        "Error"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Start",
+          "to": "RequestSent"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Reply",
+          "to": "Completed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Timeout",
+          "to": "Failed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Error",
+          "to": "Failed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.InquiryGetPropertyData",
+      "states": [
+        "Idle",
+        "RequestSent",
+        "Chunking",
+        "Completed",
+        "Failed"
+      ],
+      "events": [
+        "Start",
+        "ReplyChunk",
+        "Reply",
+        "Timeout",
+        "Error"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Start",
+          "to": "RequestSent"
+        },
+        {
+          "from": "RequestSent",
+          "on": "ReplyChunk",
+          "to": "Chunking"
+        },
+        {
+          "from": "Chunking",
+          "on": "ReplyChunk",
+          "to": "Chunking"
+        },
+        {
+          "from": "Chunking",
+          "on": "Reply",
+          "to": "Completed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Reply",
+          "to": "Completed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Timeout",
+          "to": "Failed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Error",
+          "to": "Failed"
+        },
+        {
+          "from": "Chunking",
+          "on": "Timeout",
+          "to": "Failed"
+        },
+        {
+          "from": "Chunking",
+          "on": "Error",
+          "to": "Failed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.InquiryMIDIMessageReport",
+      "states": [
+        "Idle",
+        "RequestSent",
+        "Streaming",
+        "Completed",
+        "Failed"
+      ],
+      "events": [
+        "Start",
+        "ReplyBegin",
+        "ReplyEnd",
+        "Timeout",
+        "Error"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Start",
+          "to": "RequestSent"
+        },
+        {
+          "from": "RequestSent",
+          "on": "ReplyBegin",
+          "to": "Streaming"
+        },
+        {
+          "from": "Streaming",
+          "on": "ReplyEnd",
+          "to": "Completed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Timeout",
+          "to": "Failed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Error",
+          "to": "Failed"
+        },
+        {
+          "from": "Streaming",
+          "on": "Timeout",
+          "to": "Failed"
+        },
+        {
+          "from": "Streaming",
+          "on": "Error",
+          "to": "Failed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.InquiryPropertyExchangeCapabilities",
+      "states": [
+        "Idle",
+        "RequestSent",
+        "Completed",
+        "Failed"
+      ],
+      "events": [
+        "Start",
+        "Reply",
+        "Timeout",
+        "Error"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Start",
+          "to": "RequestSent"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Reply",
+          "to": "Completed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Timeout",
+          "to": "Failed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Error",
+          "to": "Failed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.InquirySetPropertyData",
+      "states": [
+        "Idle",
+        "RequestSent",
+        "Chunking",
+        "Completed",
+        "Failed"
+      ],
+      "events": [
+        "Start",
+        "ReplyChunk",
+        "Reply",
+        "Timeout",
+        "Error"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Start",
+          "to": "RequestSent"
+        },
+        {
+          "from": "RequestSent",
+          "on": "ReplyChunk",
+          "to": "Chunking"
+        },
+        {
+          "from": "Chunking",
+          "on": "ReplyChunk",
+          "to": "Chunking"
+        },
+        {
+          "from": "Chunking",
+          "on": "Reply",
+          "to": "Completed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Reply",
+          "to": "Completed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Timeout",
+          "to": "Failed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Error",
+          "to": "Failed"
+        },
+        {
+          "from": "Chunking",
+          "on": "Timeout",
+          "to": "Failed"
+        },
+        {
+          "from": "Chunking",
+          "on": "Error",
+          "to": "Failed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.InvalidateMUID",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.MIDICIACK",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.MIDICINAK",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.NotifyMessage",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ProcessInquiryMessage",
+      "states": [
+        "Idle",
+        "RequestSent",
+        "Completed",
+        "Failed"
+      ],
+      "events": [
+        "Start",
+        "Reply",
+        "Timeout",
+        "Error"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Start",
+          "to": "RequestSent"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Reply",
+          "to": "Completed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Timeout",
+          "to": "Failed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Error",
+          "to": "Failed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ProfileAddedReportMessage",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ProfileDetailsInquiryMessage",
+      "states": [
+        "Idle",
+        "RequestSent",
+        "Completed",
+        "Failed"
+      ],
+      "events": [
+        "Start",
+        "Reply",
+        "Timeout",
+        "Error"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Start",
+          "to": "RequestSent"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Reply",
+          "to": "Completed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Timeout",
+          "to": "Failed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Error",
+          "to": "Failed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ProfileDisabledReportMessage",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ProfileEnabledReportMessage",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ProfileInquiryMessage",
+      "states": [
+        "Idle",
+        "RequestSent",
+        "Completed",
+        "Failed"
+      ],
+      "events": [
+        "Start",
+        "Reply",
+        "Timeout",
+        "Error"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Start",
+          "to": "RequestSent"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Reply",
+          "to": "Completed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Timeout",
+          "to": "Failed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Error",
+          "to": "Failed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ProfileRemovedReportMessage",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ProfileSpecificDatamessage",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ReplytoEndpointInformation",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ReplytoGetPropertyData",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
       "name": "MIDI-CI.ReplytoInitiateProtocolNegotiationMessage",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ReplytoMIDIMessageReportBegin",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ReplytoMIDIMessageReportEnd",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ReplytoProcessInquiryMessage",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ReplytoProfileDetailsInquiryMessage",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ReplytoProfileInquiryMessage",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ReplytoPropertyExchangeCapabilities",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ReplytoSetPropertyData",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.ReplytoSubscription",
       "states": [
         "Idle",
         "Completed"
@@ -5822,6 +6648,89 @@
           "from": "Idle",
           "on": "Notify",
           "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.SetProfileOffMessage",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.SetProfileOnMessage",
+      "states": [
+        "Idle",
+        "Completed"
+      ],
+      "events": [
+        "Notify"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Notify",
+          "to": "Completed"
+        }
+      ],
+      "provenance": {
+        "file": "libs/midiCITables.js",
+        "line": 35
+      }
+    },
+    {
+      "name": "MIDI-CI.Subscription",
+      "states": [
+        "Idle",
+        "RequestSent",
+        "Completed",
+        "Failed"
+      ],
+      "events": [
+        "Start",
+        "Reply",
+        "Timeout",
+        "Error"
+      ],
+      "transitions": [
+        {
+          "from": "Idle",
+          "on": "Start",
+          "to": "RequestSent"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Reply",
+          "to": "Completed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Timeout",
+          "to": "Failed"
+        },
+        {
+          "from": "RequestSent",
+          "on": "Error",
+          "to": "Failed"
         }
       ],
       "provenance": {
@@ -5910,801 +6819,14 @@
         "file": "libs/midiCITables.js",
         "line": 35
       }
-    },
-    {
-      "name": "MIDI-CI.ConfirmationNewProtocolEstablishedMessage",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ProfileInquiryMessage",
-      "states": [
-        "Idle",
-        "RequestSent",
-        "Completed",
-        "Failed"
-      ],
-      "events": [
-        "Start",
-        "Reply",
-        "Timeout",
-        "Error"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Start",
-          "to": "RequestSent"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Reply",
-          "to": "Completed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Timeout",
-          "to": "Failed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Error",
-          "to": "Failed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ReplytoProfileInquiryMessage",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.SetProfileOnMessage",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.SetProfileOffMessage",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ProfileEnabledReportMessage",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ProfileDisabledReportMessage",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ProfileAddedReportMessage",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ProfileRemovedReportMessage",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ProfileDetailsInquiryMessage",
-      "states": [
-        "Idle",
-        "RequestSent",
-        "Completed",
-        "Failed"
-      ],
-      "events": [
-        "Start",
-        "Reply",
-        "Timeout",
-        "Error"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Start",
-          "to": "RequestSent"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Reply",
-          "to": "Completed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Timeout",
-          "to": "Failed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Error",
-          "to": "Failed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ReplytoProfileDetailsInquiryMessage",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ProfileSpecificDatamessage",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.InquiryPropertyExchangeCapabilities",
-      "states": [
-        "Idle",
-        "RequestSent",
-        "Completed",
-        "Failed"
-      ],
-      "events": [
-        "Start",
-        "Reply",
-        "Timeout",
-        "Error"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Start",
-          "to": "RequestSent"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Reply",
-          "to": "Completed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Timeout",
-          "to": "Failed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Error",
-          "to": "Failed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ReplytoPropertyExchangeCapabilities",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.InquiryGetPropertyData",
-      "states": [
-        "Idle",
-        "RequestSent",
-        "Chunking",
-        "Completed",
-        "Failed"
-      ],
-      "events": [
-        "Start",
-        "ReplyChunk",
-        "Reply",
-        "Timeout",
-        "Error"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Start",
-          "to": "RequestSent"
-        },
-        {
-          "from": "RequestSent",
-          "on": "ReplyChunk",
-          "to": "Chunking"
-        },
-        {
-          "from": "Chunking",
-          "on": "ReplyChunk",
-          "to": "Chunking"
-        },
-        {
-          "from": "Chunking",
-          "on": "Reply",
-          "to": "Completed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Reply",
-          "to": "Completed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Timeout",
-          "to": "Failed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Error",
-          "to": "Failed"
-        },
-        {
-          "from": "Chunking",
-          "on": "Timeout",
-          "to": "Failed"
-        },
-        {
-          "from": "Chunking",
-          "on": "Error",
-          "to": "Failed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ReplytoGetPropertyData",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.InquirySetPropertyData",
-      "states": [
-        "Idle",
-        "RequestSent",
-        "Chunking",
-        "Completed",
-        "Failed"
-      ],
-      "events": [
-        "Start",
-        "ReplyChunk",
-        "Reply",
-        "Timeout",
-        "Error"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Start",
-          "to": "RequestSent"
-        },
-        {
-          "from": "RequestSent",
-          "on": "ReplyChunk",
-          "to": "Chunking"
-        },
-        {
-          "from": "Chunking",
-          "on": "ReplyChunk",
-          "to": "Chunking"
-        },
-        {
-          "from": "Chunking",
-          "on": "Reply",
-          "to": "Completed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Reply",
-          "to": "Completed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Timeout",
-          "to": "Failed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Error",
-          "to": "Failed"
-        },
-        {
-          "from": "Chunking",
-          "on": "Timeout",
-          "to": "Failed"
-        },
-        {
-          "from": "Chunking",
-          "on": "Error",
-          "to": "Failed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ReplytoSetPropertyData",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.Subscription",
-      "states": [
-        "Idle",
-        "RequestSent",
-        "Completed",
-        "Failed"
-      ],
-      "events": [
-        "Start",
-        "Reply",
-        "Timeout",
-        "Error"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Start",
-          "to": "RequestSent"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Reply",
-          "to": "Completed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Timeout",
-          "to": "Failed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Error",
-          "to": "Failed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ReplytoSubscription",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.NotifyMessage",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ProcessInquiryMessage",
-      "states": [
-        "Idle",
-        "RequestSent",
-        "Completed",
-        "Failed"
-      ],
-      "events": [
-        "Start",
-        "Reply",
-        "Timeout",
-        "Error"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Start",
-          "to": "RequestSent"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Reply",
-          "to": "Completed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Timeout",
-          "to": "Failed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Error",
-          "to": "Failed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ReplytoProcessInquiryMessage",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.InquiryMIDIMessageReport",
-      "states": [
-        "Idle",
-        "RequestSent",
-        "Streaming",
-        "Completed",
-        "Failed"
-      ],
-      "events": [
-        "Start",
-        "ReplyBegin",
-        "ReplyEnd",
-        "Timeout",
-        "Error"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Start",
-          "to": "RequestSent"
-        },
-        {
-          "from": "RequestSent",
-          "on": "ReplyBegin",
-          "to": "Streaming"
-        },
-        {
-          "from": "Streaming",
-          "on": "ReplyEnd",
-          "to": "Completed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Timeout",
-          "to": "Failed"
-        },
-        {
-          "from": "RequestSent",
-          "on": "Error",
-          "to": "Failed"
-        },
-        {
-          "from": "Streaming",
-          "on": "Timeout",
-          "to": "Failed"
-        },
-        {
-          "from": "Streaming",
-          "on": "Error",
-          "to": "Failed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ReplytoMIDIMessageReportBegin",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
-    },
-    {
-      "name": "MIDI-CI.ReplytoMIDIMessageReportEnd",
-      "states": [
-        "Idle",
-        "Completed"
-      ],
-      "events": [
-        "Notify"
-      ],
-      "transitions": [
-        {
-          "from": "Idle",
-          "on": "Notify",
-          "to": "Completed"
-        }
-      ],
-      "provenance": {
-        "file": "libs/midiCITables.js",
-        "line": 35
-      }
     }
   ],
   "resources": {
     "Profiles": [
       {
-        "bank": 33,
-        "index": 0,
-        "name": "Default Control Change Mapping"
-      },
-      {
         "bank": 0,
         "index": 0,
         "name": "General MIDI 2"
-      },
-      {
-        "bank": 33,
-        "index": 2,
-        "name": "General MIDI 2 Single Channel"
       },
       {
         "bank": 32,
@@ -6712,9 +6834,9 @@
         "name": "Drawbar Organ"
       },
       {
-        "bank": 97,
+        "bank": 33,
         "index": 0,
-        "name": "Rotary Speaker Effect"
+        "name": "Default Control Change Mapping"
       },
       {
         "bank": 33,
@@ -6722,13 +6844,68 @@
         "name": "Note On Orchestral Articulation"
       },
       {
+        "bank": 33,
+        "index": 2,
+        "name": "General MIDI 2 Single Channel"
+      },
+      {
         "bank": 49,
         "index": 0,
         "name": "MPE"
+      },
+      {
+        "bank": 97,
+        "index": 0,
+        "name": "Rotary Speaker Effect"
       }
     ],
     "PropertyExchange": {
       "schemas": [
+        {
+          "id": "AllCtrlList"
+        },
+        {
+          "id": "BasicChannelRx"
+        },
+        {
+          "id": "BasicChannelTx"
+        },
+        {
+          "id": "ChannelList"
+        },
+        {
+          "id": "ChannelMode"
+        },
+        {
+          "id": "ChCtrlList"
+        },
+        {
+          "id": "CtrlMapList"
+        },
+        {
+          "id": "CurrentMode"
+        },
+        {
+          "id": "DeviceInfo"
+        },
+        {
+          "id": "ExternalSync"
+        },
+        {
+          "id": "JSONSchema"
+        },
+        {
+          "id": "LocalOn"
+        },
+        {
+          "id": "MaxSysex8Streams"
+        },
+        {
+          "id": "ModeList"
+        },
+        {
+          "id": "ProgramList"
+        },
         {
           "id": "ResourceList"
         },
@@ -6736,67 +6913,52 @@
           "id": "schema"
         },
         {
-          "id": "DeviceInfo"
+          "id": "schema"
         },
         {
           "id": "schema"
         },
         {
-          "id": "ChannelList"
+          "id": "schema"
         },
         {
           "id": "schema"
         },
         {
-          "id": "JSONSchema"
+          "id": "schema"
         },
         {
           "id": "schema"
         },
         {
-          "id": "ModeList"
+          "id": "schema"
         },
         {
           "id": "schema"
         },
         {
-          "id": "CurrentMode"
+          "id": "schema"
         },
         {
           "id": "schema"
         },
         {
-          "id": "ProgramList"
+          "id": "schema"
         },
         {
           "id": "schema"
         },
         {
-          "id": "ExternalSync"
+          "id": "schema"
         },
         {
           "id": "schema"
         },
         {
-          "id": "LocalOn"
-        },
-        {
           "id": "schema"
         },
         {
-          "id": "ChannelMode"
-        },
-        {
           "id": "schema"
-        },
-        {
-          "id": "BasicChannelRx"
-        },
-        {
-          "id": "schema"
-        },
-        {
-          "id": "BasicChannelTx"
         },
         {
           "id": "schema"
@@ -6805,37 +6967,7 @@
           "id": "State"
         },
         {
-          "id": "schema"
-        },
-        {
           "id": "StateList"
-        },
-        {
-          "id": "schema"
-        },
-        {
-          "id": "MaxSysex8Streams"
-        },
-        {
-          "id": "schema"
-        },
-        {
-          "id": "AllCtrlList"
-        },
-        {
-          "id": "schema"
-        },
-        {
-          "id": "ChCtrlList"
-        },
-        {
-          "id": "schema"
-        },
-        {
-          "id": "CtrlMapList"
-        },
-        {
-          "id": "schema"
         }
       ]
     }

--- a/vectors/golden/auto_vectors.json
+++ b/vectors/golden/auto_vectors.json
@@ -1,2150 +1,6 @@
 [
   {
-    "name": "UtilityMessages.NOOP",
-    "case": "group_min",
-    "raw": "0x0",
-    "decoded": {
-      "messageType": 0,
-      "group": 0,
-      "statusCode": 0
-    }
-  },
-  {
-    "name": "UtilityMessages.NOOP",
-    "case": "group_max",
-    "raw": "0xF0",
-    "decoded": {
-      "messageType": 0,
-      "group": 15,
-      "statusCode": 0
-    }
-  },
-  {
-    "name": "UtilityMessages.JRClock",
-    "case": "group_min",
-    "raw": "0x100",
-    "decoded": {
-      "messageType": 0,
-      "group": 0,
-      "statusCode": 1
-    }
-  },
-  {
-    "name": "UtilityMessages.JRClock",
-    "case": "group_max",
-    "raw": "0x1F0",
-    "decoded": {
-      "messageType": 0,
-      "group": 15,
-      "statusCode": 1
-    }
-  },
-  {
-    "name": "UtilityMessages.JRTimestamp",
-    "case": "group_min",
-    "raw": "0x200",
-    "decoded": {
-      "messageType": 0,
-      "group": 0,
-      "statusCode": 2
-    }
-  },
-  {
-    "name": "UtilityMessages.JRTimestamp",
-    "case": "group_max",
-    "raw": "0x2F0",
-    "decoded": {
-      "messageType": 0,
-      "group": 15,
-      "statusCode": 2
-    }
-  },
-  {
-    "name": "UtilityMessages.DeltaClockstampTicksPerQuarterNote",
-    "case": "group_min",
-    "raw": "0x300",
-    "decoded": {
-      "messageType": 0,
-      "group": 0,
-      "statusCode": 3
-    }
-  },
-  {
-    "name": "UtilityMessages.DeltaClockstampTicksPerQuarterNote",
-    "case": "group_max",
-    "raw": "0x3F0",
-    "decoded": {
-      "messageType": 0,
-      "group": 15,
-      "statusCode": 3
-    }
-  },
-  {
-    "name": "UtilityMessages.DeltaClockstamp",
-    "case": "group_min",
-    "raw": "0x400",
-    "decoded": {
-      "messageType": 0,
-      "group": 0,
-      "statusCode": 4
-    }
-  },
-  {
-    "name": "UtilityMessages.DeltaClockstamp",
-    "case": "group_max",
-    "raw": "0x4F0",
-    "decoded": {
-      "messageType": 0,
-      "group": 15,
-      "statusCode": 4
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.MIDITimeCode",
-    "case": "group_min",
-    "raw": "0xF101",
-    "decoded": {
-      "messageType": 1,
-      "group": 0,
-      "statusByte": 241,
-      "nnndddd": 0
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.MIDITimeCode",
-    "case": "group_max",
-    "raw": "0xF1F1",
-    "decoded": {
-      "messageType": 1,
-      "group": 15,
-      "statusByte": 241,
-      "nnndddd": 0
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.MIDITimeCode",
-    "case": "nnndddd_min",
-    "raw": "0xF101",
-    "decoded": {
-      "messageType": 1,
-      "group": 0,
-      "statusByte": 241,
-      "nnndddd": 0
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.MIDITimeCode",
-    "case": "nnndddd_max",
-    "raw": "0xFEF101",
-    "decoded": {
-      "messageType": 1,
-      "group": 0,
-      "statusByte": 241,
-      "nnndddd": 127
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.SongPositionPointer",
-    "case": "group_min",
-    "raw": "0xF201",
-    "decoded": {
-      "messageType": 1,
-      "group": 0,
-      "statusByte": 242,
-      "lllllll": 0,
-      "mmmmmmm": 0
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.SongPositionPointer",
-    "case": "group_max",
-    "raw": "0xF2F1",
-    "decoded": {
-      "messageType": 1,
-      "group": 15,
-      "statusByte": 242,
-      "lllllll": 0,
-      "mmmmmmm": 0
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.SongPositionPointer",
-    "case": "lllllll_min",
-    "raw": "0xF201",
-    "decoded": {
-      "messageType": 1,
-      "group": 0,
-      "statusByte": 242,
-      "lllllll": 0,
-      "mmmmmmm": 0
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.SongPositionPointer",
-    "case": "lllllll_max",
-    "raw": "0xFEF201",
-    "decoded": {
-      "messageType": 1,
-      "group": 0,
-      "statusByte": 242,
-      "lllllll": 127,
-      "mmmmmmm": 0
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.SongSelect",
-    "case": "group_min",
-    "raw": "0xF301",
-    "decoded": {
-      "messageType": 1,
-      "group": 0,
-      "statusByte": 243,
-      "sssssss": 0
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.SongSelect",
-    "case": "group_max",
-    "raw": "0xF3F1",
-    "decoded": {
-      "messageType": 1,
-      "group": 15,
-      "statusByte": 243,
-      "sssssss": 0
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.SongSelect",
-    "case": "sssssss_min",
-    "raw": "0xF301",
-    "decoded": {
-      "messageType": 1,
-      "group": 0,
-      "statusByte": 243,
-      "sssssss": 0
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.SongSelect",
-    "case": "sssssss_max",
-    "raw": "0xFEF301",
-    "decoded": {
-      "messageType": 1,
-      "group": 0,
-      "statusByte": 243,
-      "sssssss": 127
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.TuneRequest",
-    "case": "group_min",
-    "raw": "0xF601",
-    "decoded": {
-      "messageType": 1,
-      "group": 0,
-      "statusByte": 246
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.TuneRequest",
-    "case": "group_max",
-    "raw": "0xF6F1",
-    "decoded": {
-      "messageType": 1,
-      "group": 15,
-      "statusByte": 246
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.TimingClock",
-    "case": "group_min",
-    "raw": "0xF801",
-    "decoded": {
-      "messageType": 1,
-      "group": 0,
-      "statusByte": 248
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.TimingClock",
-    "case": "group_max",
-    "raw": "0xF8F1",
-    "decoded": {
-      "messageType": 1,
-      "group": 15,
-      "statusByte": 248
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.Start",
-    "case": "group_min",
-    "raw": "0xFA01",
-    "decoded": {
-      "messageType": 1,
-      "group": 0,
-      "statusByte": 250
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.Start",
-    "case": "group_max",
-    "raw": "0xFAF1",
-    "decoded": {
-      "messageType": 1,
-      "group": 15,
-      "statusByte": 250
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.Continue",
-    "case": "group_min",
-    "raw": "0xFB01",
-    "decoded": {
-      "messageType": 1,
-      "group": 0,
-      "statusByte": 251
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.Continue",
-    "case": "group_max",
-    "raw": "0xFBF1",
-    "decoded": {
-      "messageType": 1,
-      "group": 15,
-      "statusByte": 251
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.Stop",
-    "case": "group_min",
-    "raw": "0xFC01",
-    "decoded": {
-      "messageType": 1,
-      "group": 0,
-      "statusByte": 252
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.Stop",
-    "case": "group_max",
-    "raw": "0xFCF1",
-    "decoded": {
-      "messageType": 1,
-      "group": 15,
-      "statusByte": 252
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.ActiveSensing",
-    "case": "group_min",
-    "raw": "0xFE01",
-    "decoded": {
-      "messageType": 1,
-      "group": 0,
-      "statusByte": 254
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.ActiveSensing",
-    "case": "group_max",
-    "raw": "0xFEF1",
-    "decoded": {
-      "messageType": 1,
-      "group": 15,
-      "statusByte": 254
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.Reset",
-    "case": "group_min",
-    "raw": "0xFF01",
-    "decoded": {
-      "messageType": 1,
-      "group": 0,
-      "statusByte": 255
-    }
-  },
-  {
-    "name": "SystemRealTimeandSystemCommonMessages.Reset",
-    "case": "group_max",
-    "raw": "0xFFF1",
-    "decoded": {
-      "messageType": 1,
-      "group": 15,
-      "statusByte": 255
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.NoteOff",
-    "case": "group_min",
-    "raw": "0x802",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 8,
-      "channel": 0,
-      "noteNumber": 0,
-      "velocity": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.NoteOff",
-    "case": "group_max",
-    "raw": "0x8F2",
-    "decoded": {
-      "messageType": 2,
-      "group": 15,
-      "statusNibble": 8,
-      "channel": 0,
-      "noteNumber": 0,
-      "velocity": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.NoteOff",
-    "case": "channel_min",
-    "raw": "0x802",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 8,
-      "channel": 0,
-      "noteNumber": 0,
-      "velocity": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.NoteOff",
-    "case": "channel_max",
-    "raw": "0xF802",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 8,
-      "channel": 15,
-      "noteNumber": 0,
-      "velocity": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.NoteOn",
-    "case": "group_min",
-    "raw": "0x902",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 9,
-      "channel": 0,
-      "noteNumber": 0,
-      "velocity": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.NoteOn",
-    "case": "group_max",
-    "raw": "0x9F2",
-    "decoded": {
-      "messageType": 2,
-      "group": 15,
-      "statusNibble": 9,
-      "channel": 0,
-      "noteNumber": 0,
-      "velocity": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.NoteOn",
-    "case": "channel_min",
-    "raw": "0x902",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 9,
-      "channel": 0,
-      "noteNumber": 0,
-      "velocity": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.NoteOn",
-    "case": "channel_max",
-    "raw": "0xF902",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 9,
-      "channel": 15,
-      "noteNumber": 0,
-      "velocity": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.PolyPressure",
-    "case": "group_min",
-    "raw": "0xA02",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 10,
-      "channel": 0,
-      "noteNumber": 0,
-      "Pressure": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.PolyPressure",
-    "case": "group_max",
-    "raw": "0xAF2",
-    "decoded": {
-      "messageType": 2,
-      "group": 15,
-      "statusNibble": 10,
-      "channel": 0,
-      "noteNumber": 0,
-      "Pressure": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.PolyPressure",
-    "case": "channel_min",
-    "raw": "0xA02",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 10,
-      "channel": 0,
-      "noteNumber": 0,
-      "Pressure": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.PolyPressure",
-    "case": "channel_max",
-    "raw": "0xFA02",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 10,
-      "channel": 15,
-      "noteNumber": 0,
-      "Pressure": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.ControlChangeMessage",
-    "case": "group_min",
-    "raw": "0xB02",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 11,
-      "channel": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.ControlChangeMessage",
-    "case": "group_max",
-    "raw": "0xBF2",
-    "decoded": {
-      "messageType": 2,
-      "group": 15,
-      "statusNibble": 11,
-      "channel": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.ControlChangeMessage",
-    "case": "channel_min",
-    "raw": "0xB02",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 11,
-      "channel": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.ControlChangeMessage",
-    "case": "channel_max",
-    "raw": "0xFB02",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 11,
-      "channel": 15,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.ProgramChangeMessage",
-    "case": "group_min",
-    "raw": "0xC02",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 12,
-      "channel": 0,
-      "program": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.ProgramChangeMessage",
-    "case": "group_max",
-    "raw": "0xCF2",
-    "decoded": {
-      "messageType": 2,
-      "group": 15,
-      "statusNibble": 12,
-      "channel": 0,
-      "program": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.ProgramChangeMessage",
-    "case": "channel_min",
-    "raw": "0xC02",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 12,
-      "channel": 0,
-      "program": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.ProgramChangeMessage",
-    "case": "channel_max",
-    "raw": "0xFC02",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 12,
-      "channel": 15,
-      "program": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.ChannelPressureMessage",
-    "case": "group_min",
-    "raw": "0xD02",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 13,
-      "channel": 0,
-      "Pressure": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.ChannelPressureMessage",
-    "case": "group_max",
-    "raw": "0xDF2",
-    "decoded": {
-      "messageType": 2,
-      "group": 15,
-      "statusNibble": 13,
-      "channel": 0,
-      "Pressure": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.ChannelPressureMessage",
-    "case": "channel_min",
-    "raw": "0xD02",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 13,
-      "channel": 0,
-      "Pressure": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.ChannelPressureMessage",
-    "case": "channel_max",
-    "raw": "0xFD02",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 13,
-      "channel": 15,
-      "Pressure": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.PitchBend",
-    "case": "group_min",
-    "raw": "0xE02",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 14,
-      "channel": 0,
-      "LSBdata": 0,
-      "MSBdata": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.PitchBend",
-    "case": "group_max",
-    "raw": "0xEF2",
-    "decoded": {
-      "messageType": 2,
-      "group": 15,
-      "statusNibble": 14,
-      "channel": 0,
-      "LSBdata": 0,
-      "MSBdata": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.PitchBend",
-    "case": "channel_min",
-    "raw": "0xE02",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 14,
-      "channel": 0,
-      "LSBdata": 0,
-      "MSBdata": 0
-    }
-  },
-  {
-    "name": "MIDI10ChannelVoiceMessages.PitchBend",
-    "case": "channel_max",
-    "raw": "0xFE02",
-    "decoded": {
-      "messageType": 2,
-      "group": 0,
-      "statusNibble": 14,
-      "channel": 15,
-      "LSBdata": 0,
-      "MSBdata": 0
-    }
-  },
-  {
-    "name": "SysEx.CompleteSystemExclusiveMessageinOnePacket",
-    "case": "group_min",
-    "raw": "0x3",
-    "decoded": {
-      "messageType": 3,
-      "group": 0,
-      "sysexForm": 0,
-      "byteCount": 0,
-      "Byte1": 0,
-      "Byte2": 0,
-      "Byte3": 0,
-      "Byte4": 0,
-      "Byte5": 0,
-      "Byte6": 0
-    }
-  },
-  {
-    "name": "SysEx.CompleteSystemExclusiveMessageinOnePacket",
-    "case": "group_max",
-    "raw": "0xF3",
-    "decoded": {
-      "messageType": 3,
-      "group": 15,
-      "sysexForm": 0,
-      "byteCount": 0,
-      "Byte1": 0,
-      "Byte2": 0,
-      "Byte3": 0,
-      "Byte4": 0,
-      "Byte5": 0,
-      "Byte6": 0
-    }
-  },
-  {
-    "name": "SysEx.CompleteSystemExclusiveMessageinOnePacket",
-    "case": "byteCount_min",
-    "raw": "0x3",
-    "decoded": {
-      "messageType": 3,
-      "group": 0,
-      "sysexForm": 0,
-      "byteCount": 0,
-      "Byte1": 0,
-      "Byte2": 0,
-      "Byte3": 0,
-      "Byte4": 0,
-      "Byte5": 0,
-      "Byte6": 0
-    }
-  },
-  {
-    "name": "SysEx.CompleteSystemExclusiveMessageinOnePacket",
-    "case": "byteCount_max",
-    "raw": "0xF003",
-    "decoded": {
-      "messageType": 3,
-      "group": 0,
-      "sysexForm": 0,
-      "byteCount": 15,
-      "Byte1": 0,
-      "Byte2": 0,
-      "Byte3": 0,
-      "Byte4": 0,
-      "Byte5": 0,
-      "Byte6": 0
-    }
-  },
-  {
-    "name": "SysEx.SystemExclusiveStartPacket",
-    "case": "group_min",
-    "raw": "0x103",
-    "decoded": {
-      "messageType": 3,
-      "group": 0,
-      "sysexForm": 1,
-      "byteCount": 0,
-      "Byte1": 0,
-      "Byte2": 0,
-      "Byte3": 0,
-      "Byte4": 0,
-      "Byte5": 0,
-      "Byte6": 0
-    }
-  },
-  {
-    "name": "SysEx.SystemExclusiveStartPacket",
-    "case": "group_max",
-    "raw": "0x1F3",
-    "decoded": {
-      "messageType": 3,
-      "group": 15,
-      "sysexForm": 1,
-      "byteCount": 0,
-      "Byte1": 0,
-      "Byte2": 0,
-      "Byte3": 0,
-      "Byte4": 0,
-      "Byte5": 0,
-      "Byte6": 0
-    }
-  },
-  {
-    "name": "SysEx.SystemExclusiveStartPacket",
-    "case": "byteCount_min",
-    "raw": "0x103",
-    "decoded": {
-      "messageType": 3,
-      "group": 0,
-      "sysexForm": 1,
-      "byteCount": 0,
-      "Byte1": 0,
-      "Byte2": 0,
-      "Byte3": 0,
-      "Byte4": 0,
-      "Byte5": 0,
-      "Byte6": 0
-    }
-  },
-  {
-    "name": "SysEx.SystemExclusiveStartPacket",
-    "case": "byteCount_max",
-    "raw": "0xF103",
-    "decoded": {
-      "messageType": 3,
-      "group": 0,
-      "sysexForm": 1,
-      "byteCount": 15,
-      "Byte1": 0,
-      "Byte2": 0,
-      "Byte3": 0,
-      "Byte4": 0,
-      "Byte5": 0,
-      "Byte6": 0
-    }
-  },
-  {
-    "name": "SysEx.SystemExclusiveContinuePacket",
-    "case": "group_min",
-    "raw": "0x203",
-    "decoded": {
-      "messageType": 3,
-      "group": 0,
-      "sysexForm": 2,
-      "byteCount": 0,
-      "Byte1": 0,
-      "Byte2": 0,
-      "Byte3": 0,
-      "Byte4": 0,
-      "Byte5": 0,
-      "Byte6": 0
-    }
-  },
-  {
-    "name": "SysEx.SystemExclusiveContinuePacket",
-    "case": "group_max",
-    "raw": "0x2F3",
-    "decoded": {
-      "messageType": 3,
-      "group": 15,
-      "sysexForm": 2,
-      "byteCount": 0,
-      "Byte1": 0,
-      "Byte2": 0,
-      "Byte3": 0,
-      "Byte4": 0,
-      "Byte5": 0,
-      "Byte6": 0
-    }
-  },
-  {
-    "name": "SysEx.SystemExclusiveContinuePacket",
-    "case": "byteCount_min",
-    "raw": "0x203",
-    "decoded": {
-      "messageType": 3,
-      "group": 0,
-      "sysexForm": 2,
-      "byteCount": 0,
-      "Byte1": 0,
-      "Byte2": 0,
-      "Byte3": 0,
-      "Byte4": 0,
-      "Byte5": 0,
-      "Byte6": 0
-    }
-  },
-  {
-    "name": "SysEx.SystemExclusiveContinuePacket",
-    "case": "byteCount_max",
-    "raw": "0xF203",
-    "decoded": {
-      "messageType": 3,
-      "group": 0,
-      "sysexForm": 2,
-      "byteCount": 15,
-      "Byte1": 0,
-      "Byte2": 0,
-      "Byte3": 0,
-      "Byte4": 0,
-      "Byte5": 0,
-      "Byte6": 0
-    }
-  },
-  {
-    "name": "SysEx.SystemExclusiveEndPacket",
-    "case": "group_min",
-    "raw": "0x303",
-    "decoded": {
-      "messageType": 3,
-      "group": 0,
-      "sysexForm": 3,
-      "byteCount": 0,
-      "Byte1": 0,
-      "Byte2": 0,
-      "Byte3": 0,
-      "Byte4": 0,
-      "Byte5": 0,
-      "Byte6": 0
-    }
-  },
-  {
-    "name": "SysEx.SystemExclusiveEndPacket",
-    "case": "group_max",
-    "raw": "0x3F3",
-    "decoded": {
-      "messageType": 3,
-      "group": 15,
-      "sysexForm": 3,
-      "byteCount": 0,
-      "Byte1": 0,
-      "Byte2": 0,
-      "Byte3": 0,
-      "Byte4": 0,
-      "Byte5": 0,
-      "Byte6": 0
-    }
-  },
-  {
-    "name": "SysEx.SystemExclusiveEndPacket",
-    "case": "byteCount_min",
-    "raw": "0x303",
-    "decoded": {
-      "messageType": 3,
-      "group": 0,
-      "sysexForm": 3,
-      "byteCount": 0,
-      "Byte1": 0,
-      "Byte2": 0,
-      "Byte3": 0,
-      "Byte4": 0,
-      "Byte5": 0,
-      "Byte6": 0
-    }
-  },
-  {
-    "name": "SysEx.SystemExclusiveEndPacket",
-    "case": "byteCount_max",
-    "raw": "0xF303",
-    "decoded": {
-      "messageType": 3,
-      "group": 0,
-      "sysexForm": 3,
-      "byteCount": 15,
-      "Byte1": 0,
-      "Byte2": 0,
-      "Byte3": 0,
-      "Byte4": 0,
-      "Byte5": 0,
-      "Byte6": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.NoteOff",
-    "case": "group_min",
-    "raw": "0x804",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 8,
-      "channel": 0,
-      "noteNumber": 0,
-      "attributeType": 0,
-      "velocity": 0,
-      "attribute": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.NoteOff",
-    "case": "group_max",
-    "raw": "0x8F4",
-    "decoded": {
-      "messageType": 4,
-      "group": 15,
-      "statusNibble": 8,
-      "channel": 0,
-      "noteNumber": 0,
-      "attributeType": 0,
-      "velocity": 0,
-      "attribute": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.NoteOff",
-    "case": "channel_min",
-    "raw": "0x804",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 8,
-      "channel": 0,
-      "noteNumber": 0,
-      "attributeType": 0,
-      "velocity": 0,
-      "attribute": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.NoteOff",
-    "case": "channel_max",
-    "raw": "0xF804",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 8,
-      "channel": 15,
-      "noteNumber": 0,
-      "attributeType": 0,
-      "velocity": 0,
-      "attribute": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.NoteOn",
-    "case": "group_min",
-    "raw": "0x904",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 9,
-      "channel": 0,
-      "noteNumber": 0,
-      "attributeType": 0,
-      "velocity": 0,
-      "attribute": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.NoteOn",
-    "case": "group_max",
-    "raw": "0x9F4",
-    "decoded": {
-      "messageType": 4,
-      "group": 15,
-      "statusNibble": 9,
-      "channel": 0,
-      "noteNumber": 0,
-      "attributeType": 0,
-      "velocity": 0,
-      "attribute": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.NoteOn",
-    "case": "channel_min",
-    "raw": "0x904",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 9,
-      "channel": 0,
-      "noteNumber": 0,
-      "attributeType": 0,
-      "velocity": 0,
-      "attribute": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.NoteOn",
-    "case": "channel_max",
-    "raw": "0xF904",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 9,
-      "channel": 15,
-      "noteNumber": 0,
-      "attributeType": 0,
-      "velocity": 0,
-      "attribute": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.PolyPressure",
-    "case": "group_min",
-    "raw": "0xA04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 10,
-      "channel": 0,
-      "noteNumber": 0,
-      "Pressure": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.PolyPressure",
-    "case": "group_max",
-    "raw": "0xAF4",
-    "decoded": {
-      "messageType": 4,
-      "group": 15,
-      "statusNibble": 10,
-      "channel": 0,
-      "noteNumber": 0,
-      "Pressure": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.PolyPressure",
-    "case": "channel_min",
-    "raw": "0xA04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 10,
-      "channel": 0,
-      "noteNumber": 0,
-      "Pressure": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.PolyPressure",
-    "case": "channel_max",
-    "raw": "0xFA04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 10,
-      "channel": 15,
-      "noteNumber": 0,
-      "Pressure": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.ControlChangeMessage",
-    "case": "group_min",
-    "raw": "0xB04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 11,
-      "channel": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.ControlChangeMessage",
-    "case": "group_max",
-    "raw": "0xBF4",
-    "decoded": {
-      "messageType": 4,
-      "group": 15,
-      "statusNibble": 11,
-      "channel": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.ControlChangeMessage",
-    "case": "channel_min",
-    "raw": "0xB04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 11,
-      "channel": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.ControlChangeMessage",
-    "case": "channel_max",
-    "raw": "0xFB04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 11,
-      "channel": 15,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.RegisteredControllerRPN",
-    "case": "group_min",
-    "raw": "0x204",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 2,
-      "channel": 0,
-      "Bank": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.RegisteredControllerRPN",
-    "case": "group_max",
-    "raw": "0x2F4",
-    "decoded": {
-      "messageType": 4,
-      "group": 15,
-      "statusNibble": 2,
-      "channel": 0,
-      "Bank": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.RegisteredControllerRPN",
-    "case": "channel_min",
-    "raw": "0x204",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 2,
-      "channel": 0,
-      "Bank": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.RegisteredControllerRPN",
-    "case": "channel_max",
-    "raw": "0xF204",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 2,
-      "channel": 15,
-      "Bank": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.AssignableControllerNRPNMessages",
-    "case": "group_min",
-    "raw": "0x304",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 3,
-      "channel": 0,
-      "Bank": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.AssignableControllerNRPNMessages",
-    "case": "group_max",
-    "raw": "0x3F4",
-    "decoded": {
-      "messageType": 4,
-      "group": 15,
-      "statusNibble": 3,
-      "channel": 0,
-      "Bank": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.AssignableControllerNRPNMessages",
-    "case": "channel_min",
-    "raw": "0x304",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 3,
-      "channel": 0,
-      "Bank": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.AssignableControllerNRPNMessages",
-    "case": "channel_max",
-    "raw": "0xF304",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 3,
-      "channel": 15,
-      "Bank": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.RelativeRegisteredControllerRPN",
-    "case": "group_min",
-    "raw": "0x404",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 4,
-      "channel": 0,
-      "Bank": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.RelativeRegisteredControllerRPN",
-    "case": "group_max",
-    "raw": "0x4F4",
-    "decoded": {
-      "messageType": 4,
-      "group": 15,
-      "statusNibble": 4,
-      "channel": 0,
-      "Bank": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.RelativeRegisteredControllerRPN",
-    "case": "channel_min",
-    "raw": "0x404",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 4,
-      "channel": 0,
-      "Bank": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.RelativeRegisteredControllerRPN",
-    "case": "channel_max",
-    "raw": "0xF404",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 4,
-      "channel": 15,
-      "Bank": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.RelativeAssignableControllerNRPN",
-    "case": "group_min",
-    "raw": "0x504",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 5,
-      "channel": 0,
-      "Bank": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.RelativeAssignableControllerNRPN",
-    "case": "group_max",
-    "raw": "0x5F4",
-    "decoded": {
-      "messageType": 4,
-      "group": 15,
-      "statusNibble": 5,
-      "channel": 0,
-      "Bank": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.RelativeAssignableControllerNRPN",
-    "case": "channel_min",
-    "raw": "0x504",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 5,
-      "channel": 0,
-      "Bank": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.RelativeAssignableControllerNRPN",
-    "case": "channel_max",
-    "raw": "0xF504",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 5,
-      "channel": 15,
-      "Bank": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.ProgramChangeMessage",
-    "case": "group_min",
-    "raw": "0xC04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 12,
-      "channel": 0,
-      "bankValid": 0,
-      "program": 0,
-      "BankMSB": 0,
-      "BankLSB": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.ProgramChangeMessage",
-    "case": "group_max",
-    "raw": "0xCF4",
-    "decoded": {
-      "messageType": 4,
-      "group": 15,
-      "statusNibble": 12,
-      "channel": 0,
-      "bankValid": 0,
-      "program": 0,
-      "BankMSB": 0,
-      "BankLSB": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.ProgramChangeMessage",
-    "case": "channel_min",
-    "raw": "0xC04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 12,
-      "channel": 0,
-      "bankValid": 0,
-      "program": 0,
-      "BankMSB": 0,
-      "BankLSB": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.ProgramChangeMessage",
-    "case": "channel_max",
-    "raw": "0xFC04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 12,
-      "channel": 15,
-      "bankValid": 0,
-      "program": 0,
-      "BankMSB": 0,
-      "BankLSB": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.ChannelPressureMessage",
-    "case": "group_min",
-    "raw": "0xD04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 13,
-      "channel": 0,
-      "Pressure": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.ChannelPressureMessage",
-    "case": "group_max",
-    "raw": "0xDF4",
-    "decoded": {
-      "messageType": 4,
-      "group": 15,
-      "statusNibble": 13,
-      "channel": 0,
-      "Pressure": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.ChannelPressureMessage",
-    "case": "channel_min",
-    "raw": "0xD04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 13,
-      "channel": 0,
-      "Pressure": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.ChannelPressureMessage",
-    "case": "channel_max",
-    "raw": "0xFD04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 13,
-      "channel": 15,
-      "Pressure": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.PitchBend",
-    "case": "group_min",
-    "raw": "0xE04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 14,
-      "channel": 0,
-      "pitch": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.PitchBend",
-    "case": "group_max",
-    "raw": "0xEF4",
-    "decoded": {
-      "messageType": 4,
-      "group": 15,
-      "statusNibble": 14,
-      "channel": 0,
-      "pitch": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.PitchBend",
-    "case": "channel_min",
-    "raw": "0xE04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 14,
-      "channel": 0,
-      "pitch": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.PitchBend",
-    "case": "channel_max",
-    "raw": "0xFE04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 14,
-      "channel": 15,
-      "pitch": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.PerNotePitchBend",
-    "case": "group_min",
-    "raw": "0x604",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 6,
-      "channel": 0,
-      "noteNumber": 0,
-      "pitch": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.PerNotePitchBend",
-    "case": "group_max",
-    "raw": "0x6F4",
-    "decoded": {
-      "messageType": 4,
-      "group": 15,
-      "statusNibble": 6,
-      "channel": 0,
-      "noteNumber": 0,
-      "pitch": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.PerNotePitchBend",
-    "case": "channel_min",
-    "raw": "0x604",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 6,
-      "channel": 0,
-      "noteNumber": 0,
-      "pitch": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.PerNotePitchBend",
-    "case": "channel_max",
-    "raw": "0xF604",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 6,
-      "channel": 15,
-      "noteNumber": 0,
-      "pitch": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.AssignablePerNoteController",
-    "case": "group_min",
-    "raw": "0x104",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 1,
-      "channel": 0,
-      "noteNumber": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.AssignablePerNoteController",
-    "case": "group_max",
-    "raw": "0x1F4",
-    "decoded": {
-      "messageType": 4,
-      "group": 15,
-      "statusNibble": 1,
-      "channel": 0,
-      "noteNumber": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.AssignablePerNoteController",
-    "case": "channel_min",
-    "raw": "0x104",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 1,
-      "channel": 0,
-      "noteNumber": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.AssignablePerNoteController",
-    "case": "channel_max",
-    "raw": "0xF104",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 1,
-      "channel": 15,
-      "noteNumber": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.RegisteredPerNoteController",
-    "case": "group_min",
-    "raw": "0x4",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 0,
-      "channel": 0,
-      "noteNumber": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.RegisteredPerNoteController",
-    "case": "group_max",
-    "raw": "0xF4",
-    "decoded": {
-      "messageType": 4,
-      "group": 15,
-      "statusNibble": 0,
-      "channel": 0,
-      "noteNumber": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.RegisteredPerNoteController",
-    "case": "channel_min",
-    "raw": "0x4",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 0,
-      "channel": 0,
-      "noteNumber": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.RegisteredPerNoteController",
-    "case": "channel_max",
-    "raw": "0xF004",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 0,
-      "channel": 15,
-      "noteNumber": 0,
-      "index": 0,
-      "value": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.PerNoteManagementMessage",
-    "case": "group_min",
-    "raw": "0xF04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 15,
-      "channel": 0,
-      "noteNumber": 0,
-      "DetachPerNotecontrollersfrompreviouslyreceivedNotes": 0,
-      "ResetSetPerNotecontrollerstodefaultvalues": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.PerNoteManagementMessage",
-    "case": "group_max",
-    "raw": "0xFF4",
-    "decoded": {
-      "messageType": 4,
-      "group": 15,
-      "statusNibble": 15,
-      "channel": 0,
-      "noteNumber": 0,
-      "DetachPerNotecontrollersfrompreviouslyreceivedNotes": 0,
-      "ResetSetPerNotecontrollerstodefaultvalues": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.PerNoteManagementMessage",
-    "case": "channel_min",
-    "raw": "0xF04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 15,
-      "channel": 0,
-      "noteNumber": 0,
-      "DetachPerNotecontrollersfrompreviouslyreceivedNotes": 0,
-      "ResetSetPerNotecontrollerstodefaultvalues": 0
-    }
-  },
-  {
-    "name": "MIDI20ChannelVoiceMessages.PerNoteManagementMessage",
-    "case": "channel_max",
-    "raw": "0xFF04",
-    "decoded": {
-      "messageType": 4,
-      "group": 0,
-      "statusNibble": 15,
-      "channel": 15,
-      "noteNumber": 0,
-      "DetachPerNotecontrollersfrompreviouslyreceivedNotes": 0,
-      "ResetSetPerNotecontrollerstodefaultvalues": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.CompleteSystemExclusive8MessageinOnePacket",
-    "case": "group_min",
-    "raw": "0x5",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 0,
-      "byteCount": 0,
-      "streamid": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.CompleteSystemExclusive8MessageinOnePacket",
-    "case": "group_max",
-    "raw": "0xF5",
-    "decoded": {
-      "messageType": 5,
-      "group": 15,
-      "sysex8Form": 0,
-      "byteCount": 0,
-      "streamid": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.CompleteSystemExclusive8MessageinOnePacket",
-    "case": "byteCount_min",
-    "raw": "0x5",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 0,
-      "byteCount": 0,
-      "streamid": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.CompleteSystemExclusive8MessageinOnePacket",
-    "case": "byteCount_max",
-    "raw": "0xF005",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 0,
-      "byteCount": 15,
-      "streamid": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.SystemExclusive8StartPacket",
-    "case": "group_min",
-    "raw": "0x105",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 1,
-      "byteCount": 0,
-      "streamid": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.SystemExclusive8StartPacket",
-    "case": "group_max",
-    "raw": "0x1F5",
-    "decoded": {
-      "messageType": 5,
-      "group": 15,
-      "sysex8Form": 1,
-      "byteCount": 0,
-      "streamid": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.SystemExclusive8StartPacket",
-    "case": "byteCount_min",
-    "raw": "0x105",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 1,
-      "byteCount": 0,
-      "streamid": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.SystemExclusive8StartPacket",
-    "case": "byteCount_max",
-    "raw": "0xF105",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 1,
-      "byteCount": 15,
-      "streamid": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.SystemExclusive8ContinuePacket",
-    "case": "group_min",
-    "raw": "0x205",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 2,
-      "byteCount": 0,
-      "streamid": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.SystemExclusive8ContinuePacket",
-    "case": "group_max",
-    "raw": "0x2F5",
-    "decoded": {
-      "messageType": 5,
-      "group": 15,
-      "sysex8Form": 2,
-      "byteCount": 0,
-      "streamid": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.SystemExclusive8ContinuePacket",
-    "case": "byteCount_min",
-    "raw": "0x205",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 2,
-      "byteCount": 0,
-      "streamid": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.SystemExclusive8ContinuePacket",
-    "case": "byteCount_max",
-    "raw": "0xF205",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 2,
-      "byteCount": 15,
-      "streamid": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.SystemExclusiveEndPacket",
-    "case": "group_min",
-    "raw": "0x305",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 3,
-      "byteCount": 0,
-      "streamid": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.SystemExclusiveEndPacket",
-    "case": "group_max",
-    "raw": "0x3F5",
-    "decoded": {
-      "messageType": 5,
-      "group": 15,
-      "sysex8Form": 3,
-      "byteCount": 0,
-      "streamid": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.SystemExclusiveEndPacket",
-    "case": "byteCount_min",
-    "raw": "0x305",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 3,
-      "byteCount": 0,
-      "streamid": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.SystemExclusiveEndPacket",
-    "case": "byteCount_max",
-    "raw": "0xF305",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 3,
-      "byteCount": 15,
-      "streamid": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.MixedDataSetHeader",
-    "case": "group_min",
-    "raw": "0x805",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 8,
-      "byteCount": 0,
-      "mdsId": 0,
-      "numberofvalidbytesinthismessagechunk": 0,
-      "numberofchunksinmixeddataset": 0,
-      "numberofthischunk": 0,
-      "manufacturerid": 0,
-      "deviceid": 0,
-      "subid1": 0,
-      "subid2": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.MixedDataSetHeader",
-    "case": "group_max",
-    "raw": "0x8F5",
-    "decoded": {
-      "messageType": 5,
-      "group": 15,
-      "sysex8Form": 8,
-      "byteCount": 0,
-      "mdsId": 0,
-      "numberofvalidbytesinthismessagechunk": 0,
-      "numberofchunksinmixeddataset": 0,
-      "numberofthischunk": 0,
-      "manufacturerid": 0,
-      "deviceid": 0,
-      "subid1": 0,
-      "subid2": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.MixedDataSetHeader",
-    "case": "byteCount_min",
-    "raw": "0x805",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 8,
-      "byteCount": 0,
-      "mdsId": 0,
-      "numberofvalidbytesinthismessagechunk": 0,
-      "numberofchunksinmixeddataset": 0,
-      "numberofthischunk": 0,
-      "manufacturerid": 0,
-      "deviceid": 0,
-      "subid1": 0,
-      "subid2": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.MixedDataSetHeader",
-    "case": "byteCount_max",
-    "raw": "0xF805",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 8,
-      "byteCount": 15,
-      "mdsId": 0,
-      "numberofvalidbytesinthismessagechunk": 0,
-      "numberofchunksinmixeddataset": 0,
-      "numberofthischunk": 0,
-      "manufacturerid": 0,
-      "deviceid": 0,
-      "subid1": 0,
-      "subid2": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.MixedDataSetPayload",
-    "case": "group_min",
-    "raw": "0x905",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 9,
-      "byteCount": 0,
-      "mdsId": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.MixedDataSetPayload",
-    "case": "group_max",
-    "raw": "0x9F5",
-    "decoded": {
-      "messageType": 5,
-      "group": 15,
-      "sysex8Form": 9,
-      "byteCount": 0,
-      "mdsId": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.MixedDataSetPayload",
-    "case": "byteCount_min",
-    "raw": "0x905",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 9,
-      "byteCount": 0,
-      "mdsId": 0
-    }
-  },
-  {
-    "name": "SysEx8andMDS.MixedDataSetPayload",
-    "case": "byteCount_max",
-    "raw": "0xF905",
-    "decoded": {
-      "messageType": 5,
-      "group": 0,
-      "sysex8Form": 9,
-      "byteCount": 15,
-      "mdsId": 0
-    }
-  },
-  {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x0",
+    "name": "FlexDataMessages.FlexDataMessages0x0",
     "case": "channel_min",
     "raw": "0xD",
     "decoded": {
@@ -2152,12 +8,11 @@
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 0
+      "statusMSB": 0
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x0",
+    "name": "FlexDataMessages.FlexDataMessages0x0",
     "case": "channel_max",
     "raw": "0xFD",
     "decoded": {
@@ -2165,12 +20,11 @@
       "channel": 15,
       "group": 0,
       "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 0
+      "statusMSB": 0
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x0",
+    "name": "FlexDataMessages.FlexDataMessages0x0",
     "case": "group_min",
     "raw": "0xD",
     "decoded": {
@@ -2178,12 +32,11 @@
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 0
+      "statusMSB": 0
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x0",
+    "name": "FlexDataMessages.FlexDataMessages0x0",
     "case": "group_max",
     "raw": "0xF0D",
     "decoded": {
@@ -2191,224 +44,55 @@
       "channel": 0,
       "group": 15,
       "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 0
+      "statusMSB": 0
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x1",
+    "name": "FlexDataMessages.FlexDataMessages0x0",
     "case": "channel_min",
-    "raw": "0x100000D",
+    "raw": "0xD",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 1
+      "statusMSB": 0
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x1",
+    "name": "FlexDataMessages.FlexDataMessages0x0",
     "case": "channel_max",
-    "raw": "0x10000FD",
+    "raw": "0xFD",
     "decoded": {
       "messageType": 13,
       "channel": 15,
       "group": 0,
       "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 1
+      "statusMSB": 0
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x1",
+    "name": "FlexDataMessages.FlexDataMessages0x0",
     "case": "group_min",
-    "raw": "0x100000D",
+    "raw": "0xD",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 1
+      "statusMSB": 0
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x1",
+    "name": "FlexDataMessages.FlexDataMessages0x0",
     "case": "group_max",
-    "raw": "0x1000F0D",
+    "raw": "0xF0D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 15,
       "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 1
-    }
-  },
-  {
-    "name": "FlexDataMessages.SubdivisionClicks1SubdivisionClicks1",
-    "case": "channel_min",
-    "raw": "0x200000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 2,
-      "SubdivisionClicks1": 0,
-      "SubdivisionClicks2": 0
-    }
-  },
-  {
-    "name": "FlexDataMessages.SubdivisionClicks1SubdivisionClicks1",
-    "case": "channel_max",
-    "raw": "0x20000FD",
-    "decoded": {
-      "messageType": 13,
-      "channel": 15,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 2,
-      "SubdivisionClicks1": 0,
-      "SubdivisionClicks2": 0
-    }
-  },
-  {
-    "name": "FlexDataMessages.SubdivisionClicks1SubdivisionClicks1",
-    "case": "group_min",
-    "raw": "0x200000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 2,
-      "SubdivisionClicks1": 0,
-      "SubdivisionClicks2": 0
-    }
-  },
-  {
-    "name": "FlexDataMessages.SubdivisionClicks1SubdivisionClicks1",
-    "case": "group_max",
-    "raw": "0x2000F0D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 15,
-      "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 2,
-      "SubdivisionClicks1": 0,
-      "SubdivisionClicks2": 0
-    }
-  },
-  {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x5",
-    "case": "channel_min",
-    "raw": "0x500000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 5
-    }
-  },
-  {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x5",
-    "case": "channel_max",
-    "raw": "0x50000FD",
-    "decoded": {
-      "messageType": 13,
-      "channel": 15,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 5
-    }
-  },
-  {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x5",
-    "case": "group_min",
-    "raw": "0x500000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 5
-    }
-  },
-  {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x5",
-    "case": "group_max",
-    "raw": "0x5000F0D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 15,
-      "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 5
-    }
-  },
-  {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x6",
-    "case": "channel_min",
-    "raw": "0x600000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 6
-    }
-  },
-  {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x6",
-    "case": "channel_max",
-    "raw": "0x60000FD",
-    "decoded": {
-      "messageType": 13,
-      "channel": 15,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 6
-    }
-  },
-  {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x6",
-    "case": "group_min",
-    "raw": "0x600000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 6
-    }
-  },
-  {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x6",
-    "case": "group_max",
-    "raw": "0x6000F0D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 15,
-      "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 6
+      "statusMSB": 0
     }
   },
   {
@@ -2508,155 +192,99 @@
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1",
+    "name": "FlexDataMessages.FlexDataMessages0x1",
     "case": "channel_min",
-    "raw": "0x2000D",
+    "raw": "0x1000D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 2,
-      "SubdivisionClicks1": 0,
-      "SubdivisionClicks2": 0
+      "statusMSB": 1
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1",
+    "name": "FlexDataMessages.FlexDataMessages0x1",
     "case": "channel_max",
-    "raw": "0x200FD",
+    "raw": "0x100FD",
     "decoded": {
       "messageType": 13,
       "channel": 15,
       "group": 0,
       "form": 0,
-      "statusMSB": 2,
-      "SubdivisionClicks1": 0,
-      "SubdivisionClicks2": 0
+      "statusMSB": 1
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1",
+    "name": "FlexDataMessages.FlexDataMessages0x1",
     "case": "group_min",
-    "raw": "0x2000D",
+    "raw": "0x1000D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 2,
-      "SubdivisionClicks1": 0,
-      "SubdivisionClicks2": 0
+      "statusMSB": 1
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1",
+    "name": "FlexDataMessages.FlexDataMessages0x1",
     "case": "group_max",
-    "raw": "0x20F0D",
+    "raw": "0x10F0D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 15,
       "form": 0,
-      "statusMSB": 2,
-      "SubdivisionClicks1": 0,
-      "SubdivisionClicks2": 0
+      "statusMSB": 1
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x5",
+    "name": "FlexDataMessages.FlexDataMessages0x1",
     "case": "channel_min",
-    "raw": "0x5000D",
+    "raw": "0x1000D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 5
+      "statusMSB": 1
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x5",
+    "name": "FlexDataMessages.FlexDataMessages0x1",
     "case": "channel_max",
-    "raw": "0x500FD",
+    "raw": "0x100FD",
     "decoded": {
       "messageType": 13,
       "channel": 15,
       "group": 0,
       "form": 0,
-      "statusMSB": 5
+      "statusMSB": 1
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x5",
+    "name": "FlexDataMessages.FlexDataMessages0x1",
     "case": "group_min",
-    "raw": "0x5000D",
+    "raw": "0x1000D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 5
+      "statusMSB": 1
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x5",
+    "name": "FlexDataMessages.FlexDataMessages0x1",
     "case": "group_max",
-    "raw": "0x50F0D",
+    "raw": "0x10F0D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 15,
       "form": 0,
-      "statusMSB": 5
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x6",
-    "case": "channel_min",
-    "raw": "0x6000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 6
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x6",
-    "case": "channel_max",
-    "raw": "0x600FD",
-    "decoded": {
-      "messageType": 13,
-      "channel": 15,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 6
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x6",
-    "case": "group_min",
-    "raw": "0x6000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 6
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x6",
-    "case": "group_max",
-    "raw": "0x60F0D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 15,
-      "form": 0,
-      "statusMSB": 6
+      "statusMSB": 1
     }
   },
   {
@@ -3336,99 +964,51 @@
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x0",
+    "name": "FlexDataMessages.FlexDataMessages0x2",
     "case": "channel_min",
-    "raw": "0xD",
+    "raw": "0x2000D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 0
+      "statusMSB": 2
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x0",
+    "name": "FlexDataMessages.FlexDataMessages0x2",
     "case": "channel_max",
-    "raw": "0xFD",
+    "raw": "0x200FD",
     "decoded": {
       "messageType": 13,
       "channel": 15,
       "group": 0,
       "form": 0,
-      "statusMSB": 0
+      "statusMSB": 2
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x0",
+    "name": "FlexDataMessages.FlexDataMessages0x2",
     "case": "group_min",
-    "raw": "0xD",
+    "raw": "0x2000D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 0
+      "statusMSB": 2
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x0",
+    "name": "FlexDataMessages.FlexDataMessages0x2",
     "case": "group_max",
-    "raw": "0xF0D",
+    "raw": "0x20F0D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 15,
       "form": 0,
-      "statusMSB": 0
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x1",
-    "case": "channel_min",
-    "raw": "0x1000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 1
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x1",
-    "case": "channel_max",
-    "raw": "0x100FD",
-    "decoded": {
-      "messageType": 13,
-      "channel": 15,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 1
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x1",
-    "case": "group_min",
-    "raw": "0x1000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 1
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x1",
-    "case": "group_max",
-    "raw": "0x10F0D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 15,
-      "form": 0,
-      "statusMSB": 1
+      "statusMSB": 2
     }
   },
   {
@@ -3477,6 +1057,314 @@
       "group": 15,
       "form": 0,
       "statusMSB": 2
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x0",
+    "case": "channel_min",
+    "raw": "0x2000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 0
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x0",
+    "case": "channel_max",
+    "raw": "0x200FD",
+    "decoded": {
+      "messageType": 13,
+      "channel": 15,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 0
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x0",
+    "case": "group_min",
+    "raw": "0x2000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 0
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x0",
+    "case": "group_max",
+    "raw": "0x20F0D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 15,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 0
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x1",
+    "case": "channel_min",
+    "raw": "0x102000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 1
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x1",
+    "case": "channel_max",
+    "raw": "0x10200FD",
+    "decoded": {
+      "messageType": 13,
+      "channel": 15,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 1
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x1",
+    "case": "group_min",
+    "raw": "0x102000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 1
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x1",
+    "case": "group_max",
+    "raw": "0x1020F0D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 15,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 1
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x2",
+    "case": "channel_min",
+    "raw": "0x202000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 2
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x2",
+    "case": "channel_max",
+    "raw": "0x20200FD",
+    "decoded": {
+      "messageType": 13,
+      "channel": 15,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 2
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x2",
+    "case": "group_min",
+    "raw": "0x202000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 2
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x2",
+    "case": "group_max",
+    "raw": "0x2020F0D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 15,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 2
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x3",
+    "case": "channel_min",
+    "raw": "0x302000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 3
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x3",
+    "case": "channel_max",
+    "raw": "0x30200FD",
+    "decoded": {
+      "messageType": 13,
+      "channel": 15,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 3
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x3",
+    "case": "group_min",
+    "raw": "0x302000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 3
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x3",
+    "case": "group_max",
+    "raw": "0x3020F0D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 15,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 3
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x4",
+    "case": "channel_min",
+    "raw": "0x402000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 4
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x4",
+    "case": "channel_max",
+    "raw": "0x40200FD",
+    "decoded": {
+      "messageType": 13,
+      "channel": 15,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 4
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x4",
+    "case": "group_min",
+    "raw": "0x402000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 4
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x4",
+    "case": "group_max",
+    "raw": "0x4020F0D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 15,
+      "form": 0,
+      "statusMSB": 2,
+      "statusLSB": 4
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x3",
+    "case": "channel_min",
+    "raw": "0x3000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 3
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x3",
+    "case": "channel_max",
+    "raw": "0x300FD",
+    "decoded": {
+      "messageType": 13,
+      "channel": 15,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 3
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x3",
+    "case": "group_min",
+    "raw": "0x3000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 3
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x3",
+    "case": "group_max",
+    "raw": "0x30F0D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 15,
+      "form": 0,
+      "statusMSB": 3
     }
   },
   {
@@ -3576,6 +1464,54 @@
     }
   },
   {
+    "name": "FlexDataMessages.FlexDataMessages0x4",
+    "case": "channel_min",
+    "raw": "0x4000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 4
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x4",
+    "case": "channel_max",
+    "raw": "0x400FD",
+    "decoded": {
+      "messageType": 13,
+      "channel": 15,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 4
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x4",
+    "case": "group_min",
+    "raw": "0x4000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 4
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x4",
+    "case": "group_max",
+    "raw": "0x40F0D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 15,
+      "form": 0,
+      "statusMSB": 4
+    }
+  },
+  {
     "name": "FlexDataMessages.FlexDataMessages0x5",
     "case": "channel_min",
     "raw": "0x5000D",
@@ -3621,6 +1557,102 @@
       "group": 15,
       "form": 0,
       "statusMSB": 5
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x5",
+    "case": "channel_min",
+    "raw": "0x5000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 5
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x5",
+    "case": "channel_max",
+    "raw": "0x500FD",
+    "decoded": {
+      "messageType": 13,
+      "channel": 15,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 5
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x5",
+    "case": "group_min",
+    "raw": "0x5000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 5
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x5",
+    "case": "group_max",
+    "raw": "0x50F0D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 15,
+      "form": 0,
+      "statusMSB": 5
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x6",
+    "case": "channel_min",
+    "raw": "0x6000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 6
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x6",
+    "case": "channel_max",
+    "raw": "0x600FD",
+    "decoded": {
+      "messageType": 13,
+      "channel": 15,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 6
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x6",
+    "case": "group_min",
+    "raw": "0x6000D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 0,
+      "form": 0,
+      "statusMSB": 6
+    }
+  },
+  {
+    "name": "FlexDataMessages.FlexDataMessages0x6",
+    "case": "group_max",
+    "raw": "0x60F0D",
+    "decoded": {
+      "messageType": 13,
+      "channel": 0,
+      "group": 15,
+      "form": 0,
+      "statusMSB": 6
     }
   },
   {
@@ -3960,7 +1992,7 @@
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x0",
+    "name": "FlexDataMessages.SubdivisionClicks1",
     "case": "channel_min",
     "raw": "0x2000D",
     "decoded": {
@@ -3969,11 +2001,12 @@
       "group": 0,
       "form": 0,
       "statusMSB": 2,
-      "statusLSB": 0
+      "SubdivisionClicks1": 0,
+      "SubdivisionClicks2": 0
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x0",
+    "name": "FlexDataMessages.SubdivisionClicks1",
     "case": "channel_max",
     "raw": "0x200FD",
     "decoded": {
@@ -3982,11 +2015,12 @@
       "group": 0,
       "form": 0,
       "statusMSB": 2,
-      "statusLSB": 0
+      "SubdivisionClicks1": 0,
+      "SubdivisionClicks2": 0
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x0",
+    "name": "FlexDataMessages.SubdivisionClicks1",
     "case": "group_min",
     "raw": "0x2000D",
     "decoded": {
@@ -3995,11 +2029,12 @@
       "group": 0,
       "form": 0,
       "statusMSB": 2,
-      "statusLSB": 0
+      "SubdivisionClicks1": 0,
+      "SubdivisionClicks2": 0
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x0",
+    "name": "FlexDataMessages.SubdivisionClicks1",
     "case": "group_max",
     "raw": "0x20F0D",
     "decoded": {
@@ -4008,219 +2043,12 @@
       "group": 15,
       "form": 0,
       "statusMSB": 2,
-      "statusLSB": 0
+      "SubdivisionClicks1": 0,
+      "SubdivisionClicks2": 0
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x1",
-    "case": "channel_min",
-    "raw": "0x102000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 2,
-      "statusLSB": 1
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x1",
-    "case": "channel_max",
-    "raw": "0x10200FD",
-    "decoded": {
-      "messageType": 13,
-      "channel": 15,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 2,
-      "statusLSB": 1
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x1",
-    "case": "group_min",
-    "raw": "0x102000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 2,
-      "statusLSB": 1
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x1",
-    "case": "group_max",
-    "raw": "0x1020F0D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 15,
-      "form": 0,
-      "statusMSB": 2,
-      "statusLSB": 1
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x2",
-    "case": "channel_min",
-    "raw": "0x202000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 2,
-      "statusLSB": 2
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x2",
-    "case": "channel_max",
-    "raw": "0x20200FD",
-    "decoded": {
-      "messageType": 13,
-      "channel": 15,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 2,
-      "statusLSB": 2
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x2",
-    "case": "group_min",
-    "raw": "0x202000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 2,
-      "statusLSB": 2
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x2",
-    "case": "group_max",
-    "raw": "0x2020F0D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 15,
-      "form": 0,
-      "statusMSB": 2,
-      "statusLSB": 2
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x3",
-    "case": "channel_min",
-    "raw": "0x302000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 2,
-      "statusLSB": 3
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x3",
-    "case": "channel_max",
-    "raw": "0x30200FD",
-    "decoded": {
-      "messageType": 13,
-      "channel": 15,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 2,
-      "statusLSB": 3
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x3",
-    "case": "group_min",
-    "raw": "0x302000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 2,
-      "statusLSB": 3
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x3",
-    "case": "group_max",
-    "raw": "0x3020F0D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 15,
-      "form": 0,
-      "statusMSB": 2,
-      "statusLSB": 3
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x4",
-    "case": "channel_min",
-    "raw": "0x402000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 2,
-      "statusLSB": 4
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x4",
-    "case": "channel_max",
-    "raw": "0x40200FD",
-    "decoded": {
-      "messageType": 13,
-      "channel": 15,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 2,
-      "statusLSB": 4
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x4",
-    "case": "group_min",
-    "raw": "0x402000D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 0,
-      "form": 0,
-      "statusMSB": 2,
-      "statusLSB": 4
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x2FlexDataMessages0x4",
-    "case": "group_max",
-    "raw": "0x4020F0D",
-    "decoded": {
-      "messageType": 13,
-      "channel": 0,
-      "group": 15,
-      "form": 0,
-      "statusMSB": 2,
-      "statusLSB": 4
-    }
-  },
-  {
-    "name": "FlexDataMessages.FlexDataMessages0x0",
+    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x0",
     "case": "channel_min",
     "raw": "0xD",
     "decoded": {
@@ -4228,11 +2056,12 @@
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 0
+      "statusMSB": 0,
+      "statusLSB": 0
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x0",
+    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x0",
     "case": "channel_max",
     "raw": "0xFD",
     "decoded": {
@@ -4240,11 +2069,12 @@
       "channel": 15,
       "group": 0,
       "form": 0,
-      "statusMSB": 0
+      "statusMSB": 0,
+      "statusLSB": 0
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x0",
+    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x0",
     "case": "group_min",
     "raw": "0xD",
     "decoded": {
@@ -4252,11 +2082,12 @@
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 0
+      "statusMSB": 0,
+      "statusLSB": 0
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x0",
+    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x0",
     "case": "group_max",
     "raw": "0xF0D",
     "decoded": {
@@ -4264,199 +2095,1648 @@
       "channel": 0,
       "group": 15,
       "form": 0,
-      "statusMSB": 0
+      "statusMSB": 0,
+      "statusLSB": 0
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x1",
+    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x1",
     "case": "channel_min",
-    "raw": "0x1000D",
+    "raw": "0x100000D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 1
+      "statusMSB": 0,
+      "statusLSB": 1
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x1",
+    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x1",
     "case": "channel_max",
-    "raw": "0x100FD",
+    "raw": "0x10000FD",
     "decoded": {
       "messageType": 13,
       "channel": 15,
       "group": 0,
       "form": 0,
-      "statusMSB": 1
+      "statusMSB": 0,
+      "statusLSB": 1
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x1",
+    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x1",
     "case": "group_min",
-    "raw": "0x1000D",
+    "raw": "0x100000D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 1
+      "statusMSB": 0,
+      "statusLSB": 1
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x1",
+    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x1",
     "case": "group_max",
-    "raw": "0x10F0D",
+    "raw": "0x1000F0D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 15,
       "form": 0,
-      "statusMSB": 1
+      "statusMSB": 0,
+      "statusLSB": 1
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x2",
+    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x5",
     "case": "channel_min",
-    "raw": "0x2000D",
+    "raw": "0x500000D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 2
+      "statusMSB": 0,
+      "statusLSB": 5
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x2",
+    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x5",
     "case": "channel_max",
-    "raw": "0x200FD",
+    "raw": "0x50000FD",
     "decoded": {
       "messageType": 13,
       "channel": 15,
       "group": 0,
       "form": 0,
-      "statusMSB": 2
+      "statusMSB": 0,
+      "statusLSB": 5
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x2",
+    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x5",
     "case": "group_min",
-    "raw": "0x2000D",
+    "raw": "0x500000D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 2
+      "statusMSB": 0,
+      "statusLSB": 5
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x2",
+    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x5",
     "case": "group_max",
-    "raw": "0x20F0D",
+    "raw": "0x5000F0D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 15,
       "form": 0,
-      "statusMSB": 2
+      "statusMSB": 0,
+      "statusLSB": 5
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x3",
+    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x6",
     "case": "channel_min",
-    "raw": "0x3000D",
+    "raw": "0x600000D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 3
+      "statusMSB": 0,
+      "statusLSB": 6
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x3",
+    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x6",
     "case": "channel_max",
-    "raw": "0x300FD",
+    "raw": "0x60000FD",
     "decoded": {
       "messageType": 13,
       "channel": 15,
       "group": 0,
       "form": 0,
-      "statusMSB": 3
+      "statusMSB": 0,
+      "statusLSB": 6
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x3",
+    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x6",
     "case": "group_min",
-    "raw": "0x3000D",
+    "raw": "0x600000D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 3
+      "statusMSB": 0,
+      "statusLSB": 6
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x3",
+    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x6",
     "case": "group_max",
-    "raw": "0x30F0D",
+    "raw": "0x6000F0D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 15,
       "form": 0,
-      "statusMSB": 3
+      "statusMSB": 0,
+      "statusLSB": 6
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x4",
+    "name": "FlexDataMessages.SubdivisionClicks1SubdivisionClicks1",
     "case": "channel_min",
-    "raw": "0x4000D",
+    "raw": "0x200000D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 4
+      "statusMSB": 0,
+      "statusLSB": 2,
+      "SubdivisionClicks1": 0,
+      "SubdivisionClicks2": 0
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x4",
+    "name": "FlexDataMessages.SubdivisionClicks1SubdivisionClicks1",
     "case": "channel_max",
-    "raw": "0x400FD",
+    "raw": "0x20000FD",
     "decoded": {
       "messageType": 13,
       "channel": 15,
       "group": 0,
       "form": 0,
-      "statusMSB": 4
+      "statusMSB": 0,
+      "statusLSB": 2,
+      "SubdivisionClicks1": 0,
+      "SubdivisionClicks2": 0
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x4",
+    "name": "FlexDataMessages.SubdivisionClicks1SubdivisionClicks1",
     "case": "group_min",
-    "raw": "0x4000D",
+    "raw": "0x200000D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 0,
       "form": 0,
-      "statusMSB": 4
+      "statusMSB": 0,
+      "statusLSB": 2,
+      "SubdivisionClicks1": 0,
+      "SubdivisionClicks2": 0
     }
   },
   {
-    "name": "FlexDataMessages.FlexDataMessages0x4",
+    "name": "FlexDataMessages.SubdivisionClicks1SubdivisionClicks1",
     "case": "group_max",
-    "raw": "0x40F0D",
+    "raw": "0x2000F0D",
     "decoded": {
       "messageType": 13,
       "channel": 0,
       "group": 15,
       "form": 0,
-      "statusMSB": 4
+      "statusMSB": 0,
+      "statusLSB": 2,
+      "SubdivisionClicks1": 0,
+      "SubdivisionClicks2": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.ChannelPressureMessage",
+    "case": "group_min",
+    "raw": "0xD02",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 13,
+      "channel": 0,
+      "Pressure": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.ChannelPressureMessage",
+    "case": "group_max",
+    "raw": "0xDF2",
+    "decoded": {
+      "messageType": 2,
+      "group": 15,
+      "statusNibble": 13,
+      "channel": 0,
+      "Pressure": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.ChannelPressureMessage",
+    "case": "channel_min",
+    "raw": "0xD02",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 13,
+      "channel": 0,
+      "Pressure": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.ChannelPressureMessage",
+    "case": "channel_max",
+    "raw": "0xFD02",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 13,
+      "channel": 15,
+      "Pressure": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.ControlChangeMessage",
+    "case": "group_min",
+    "raw": "0xB02",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 11,
+      "channel": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.ControlChangeMessage",
+    "case": "group_max",
+    "raw": "0xBF2",
+    "decoded": {
+      "messageType": 2,
+      "group": 15,
+      "statusNibble": 11,
+      "channel": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.ControlChangeMessage",
+    "case": "channel_min",
+    "raw": "0xB02",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 11,
+      "channel": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.ControlChangeMessage",
+    "case": "channel_max",
+    "raw": "0xFB02",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 11,
+      "channel": 15,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.NoteOff",
+    "case": "group_min",
+    "raw": "0x802",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 8,
+      "channel": 0,
+      "noteNumber": 0,
+      "velocity": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.NoteOff",
+    "case": "group_max",
+    "raw": "0x8F2",
+    "decoded": {
+      "messageType": 2,
+      "group": 15,
+      "statusNibble": 8,
+      "channel": 0,
+      "noteNumber": 0,
+      "velocity": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.NoteOff",
+    "case": "channel_min",
+    "raw": "0x802",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 8,
+      "channel": 0,
+      "noteNumber": 0,
+      "velocity": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.NoteOff",
+    "case": "channel_max",
+    "raw": "0xF802",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 8,
+      "channel": 15,
+      "noteNumber": 0,
+      "velocity": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.NoteOn",
+    "case": "group_min",
+    "raw": "0x902",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 9,
+      "channel": 0,
+      "noteNumber": 0,
+      "velocity": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.NoteOn",
+    "case": "group_max",
+    "raw": "0x9F2",
+    "decoded": {
+      "messageType": 2,
+      "group": 15,
+      "statusNibble": 9,
+      "channel": 0,
+      "noteNumber": 0,
+      "velocity": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.NoteOn",
+    "case": "channel_min",
+    "raw": "0x902",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 9,
+      "channel": 0,
+      "noteNumber": 0,
+      "velocity": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.NoteOn",
+    "case": "channel_max",
+    "raw": "0xF902",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 9,
+      "channel": 15,
+      "noteNumber": 0,
+      "velocity": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.PitchBend",
+    "case": "group_min",
+    "raw": "0xE02",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 14,
+      "channel": 0,
+      "LSBdata": 0,
+      "MSBdata": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.PitchBend",
+    "case": "group_max",
+    "raw": "0xEF2",
+    "decoded": {
+      "messageType": 2,
+      "group": 15,
+      "statusNibble": 14,
+      "channel": 0,
+      "LSBdata": 0,
+      "MSBdata": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.PitchBend",
+    "case": "channel_min",
+    "raw": "0xE02",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 14,
+      "channel": 0,
+      "LSBdata": 0,
+      "MSBdata": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.PitchBend",
+    "case": "channel_max",
+    "raw": "0xFE02",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 14,
+      "channel": 15,
+      "LSBdata": 0,
+      "MSBdata": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.PolyPressure",
+    "case": "group_min",
+    "raw": "0xA02",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 10,
+      "channel": 0,
+      "noteNumber": 0,
+      "Pressure": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.PolyPressure",
+    "case": "group_max",
+    "raw": "0xAF2",
+    "decoded": {
+      "messageType": 2,
+      "group": 15,
+      "statusNibble": 10,
+      "channel": 0,
+      "noteNumber": 0,
+      "Pressure": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.PolyPressure",
+    "case": "channel_min",
+    "raw": "0xA02",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 10,
+      "channel": 0,
+      "noteNumber": 0,
+      "Pressure": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.PolyPressure",
+    "case": "channel_max",
+    "raw": "0xFA02",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 10,
+      "channel": 15,
+      "noteNumber": 0,
+      "Pressure": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.ProgramChangeMessage",
+    "case": "group_min",
+    "raw": "0xC02",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 12,
+      "channel": 0,
+      "program": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.ProgramChangeMessage",
+    "case": "group_max",
+    "raw": "0xCF2",
+    "decoded": {
+      "messageType": 2,
+      "group": 15,
+      "statusNibble": 12,
+      "channel": 0,
+      "program": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.ProgramChangeMessage",
+    "case": "channel_min",
+    "raw": "0xC02",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 12,
+      "channel": 0,
+      "program": 0
+    }
+  },
+  {
+    "name": "MIDI10ChannelVoiceMessages.ProgramChangeMessage",
+    "case": "channel_max",
+    "raw": "0xFC02",
+    "decoded": {
+      "messageType": 2,
+      "group": 0,
+      "statusNibble": 12,
+      "channel": 15,
+      "program": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.AssignableControllerNRPNMessages",
+    "case": "group_min",
+    "raw": "0x304",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 3,
+      "channel": 0,
+      "Bank": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.AssignableControllerNRPNMessages",
+    "case": "group_max",
+    "raw": "0x3F4",
+    "decoded": {
+      "messageType": 4,
+      "group": 15,
+      "statusNibble": 3,
+      "channel": 0,
+      "Bank": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.AssignableControllerNRPNMessages",
+    "case": "channel_min",
+    "raw": "0x304",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 3,
+      "channel": 0,
+      "Bank": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.AssignableControllerNRPNMessages",
+    "case": "channel_max",
+    "raw": "0xF304",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 3,
+      "channel": 15,
+      "Bank": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.AssignablePerNoteController",
+    "case": "group_min",
+    "raw": "0x104",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 1,
+      "channel": 0,
+      "noteNumber": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.AssignablePerNoteController",
+    "case": "group_max",
+    "raw": "0x1F4",
+    "decoded": {
+      "messageType": 4,
+      "group": 15,
+      "statusNibble": 1,
+      "channel": 0,
+      "noteNumber": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.AssignablePerNoteController",
+    "case": "channel_min",
+    "raw": "0x104",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 1,
+      "channel": 0,
+      "noteNumber": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.AssignablePerNoteController",
+    "case": "channel_max",
+    "raw": "0xF104",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 1,
+      "channel": 15,
+      "noteNumber": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.ChannelPressureMessage",
+    "case": "group_min",
+    "raw": "0xD04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 13,
+      "channel": 0,
+      "Pressure": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.ChannelPressureMessage",
+    "case": "group_max",
+    "raw": "0xDF4",
+    "decoded": {
+      "messageType": 4,
+      "group": 15,
+      "statusNibble": 13,
+      "channel": 0,
+      "Pressure": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.ChannelPressureMessage",
+    "case": "channel_min",
+    "raw": "0xD04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 13,
+      "channel": 0,
+      "Pressure": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.ChannelPressureMessage",
+    "case": "channel_max",
+    "raw": "0xFD04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 13,
+      "channel": 15,
+      "Pressure": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.ControlChangeMessage",
+    "case": "group_min",
+    "raw": "0xB04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 11,
+      "channel": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.ControlChangeMessage",
+    "case": "group_max",
+    "raw": "0xBF4",
+    "decoded": {
+      "messageType": 4,
+      "group": 15,
+      "statusNibble": 11,
+      "channel": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.ControlChangeMessage",
+    "case": "channel_min",
+    "raw": "0xB04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 11,
+      "channel": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.ControlChangeMessage",
+    "case": "channel_max",
+    "raw": "0xFB04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 11,
+      "channel": 15,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.NoteOff",
+    "case": "group_min",
+    "raw": "0x804",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 8,
+      "channel": 0,
+      "noteNumber": 0,
+      "attributeType": 0,
+      "velocity": 0,
+      "attribute": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.NoteOff",
+    "case": "group_max",
+    "raw": "0x8F4",
+    "decoded": {
+      "messageType": 4,
+      "group": 15,
+      "statusNibble": 8,
+      "channel": 0,
+      "noteNumber": 0,
+      "attributeType": 0,
+      "velocity": 0,
+      "attribute": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.NoteOff",
+    "case": "channel_min",
+    "raw": "0x804",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 8,
+      "channel": 0,
+      "noteNumber": 0,
+      "attributeType": 0,
+      "velocity": 0,
+      "attribute": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.NoteOff",
+    "case": "channel_max",
+    "raw": "0xF804",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 8,
+      "channel": 15,
+      "noteNumber": 0,
+      "attributeType": 0,
+      "velocity": 0,
+      "attribute": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.NoteOn",
+    "case": "group_min",
+    "raw": "0x904",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 9,
+      "channel": 0,
+      "noteNumber": 0,
+      "attributeType": 0,
+      "velocity": 0,
+      "attribute": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.NoteOn",
+    "case": "group_max",
+    "raw": "0x9F4",
+    "decoded": {
+      "messageType": 4,
+      "group": 15,
+      "statusNibble": 9,
+      "channel": 0,
+      "noteNumber": 0,
+      "attributeType": 0,
+      "velocity": 0,
+      "attribute": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.NoteOn",
+    "case": "channel_min",
+    "raw": "0x904",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 9,
+      "channel": 0,
+      "noteNumber": 0,
+      "attributeType": 0,
+      "velocity": 0,
+      "attribute": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.NoteOn",
+    "case": "channel_max",
+    "raw": "0xF904",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 9,
+      "channel": 15,
+      "noteNumber": 0,
+      "attributeType": 0,
+      "velocity": 0,
+      "attribute": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.PerNoteManagementMessage",
+    "case": "group_min",
+    "raw": "0xF04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 15,
+      "channel": 0,
+      "noteNumber": 0,
+      "DetachPerNotecontrollersfrompreviouslyreceivedNotes": 0,
+      "ResetSetPerNotecontrollerstodefaultvalues": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.PerNoteManagementMessage",
+    "case": "group_max",
+    "raw": "0xFF4",
+    "decoded": {
+      "messageType": 4,
+      "group": 15,
+      "statusNibble": 15,
+      "channel": 0,
+      "noteNumber": 0,
+      "DetachPerNotecontrollersfrompreviouslyreceivedNotes": 0,
+      "ResetSetPerNotecontrollerstodefaultvalues": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.PerNoteManagementMessage",
+    "case": "channel_min",
+    "raw": "0xF04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 15,
+      "channel": 0,
+      "noteNumber": 0,
+      "DetachPerNotecontrollersfrompreviouslyreceivedNotes": 0,
+      "ResetSetPerNotecontrollerstodefaultvalues": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.PerNoteManagementMessage",
+    "case": "channel_max",
+    "raw": "0xFF04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 15,
+      "channel": 15,
+      "noteNumber": 0,
+      "DetachPerNotecontrollersfrompreviouslyreceivedNotes": 0,
+      "ResetSetPerNotecontrollerstodefaultvalues": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.PerNotePitchBend",
+    "case": "group_min",
+    "raw": "0x604",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 6,
+      "channel": 0,
+      "noteNumber": 0,
+      "pitch": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.PerNotePitchBend",
+    "case": "group_max",
+    "raw": "0x6F4",
+    "decoded": {
+      "messageType": 4,
+      "group": 15,
+      "statusNibble": 6,
+      "channel": 0,
+      "noteNumber": 0,
+      "pitch": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.PerNotePitchBend",
+    "case": "channel_min",
+    "raw": "0x604",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 6,
+      "channel": 0,
+      "noteNumber": 0,
+      "pitch": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.PerNotePitchBend",
+    "case": "channel_max",
+    "raw": "0xF604",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 6,
+      "channel": 15,
+      "noteNumber": 0,
+      "pitch": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.PitchBend",
+    "case": "group_min",
+    "raw": "0xE04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 14,
+      "channel": 0,
+      "pitch": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.PitchBend",
+    "case": "group_max",
+    "raw": "0xEF4",
+    "decoded": {
+      "messageType": 4,
+      "group": 15,
+      "statusNibble": 14,
+      "channel": 0,
+      "pitch": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.PitchBend",
+    "case": "channel_min",
+    "raw": "0xE04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 14,
+      "channel": 0,
+      "pitch": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.PitchBend",
+    "case": "channel_max",
+    "raw": "0xFE04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 14,
+      "channel": 15,
+      "pitch": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.PolyPressure",
+    "case": "group_min",
+    "raw": "0xA04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 10,
+      "channel": 0,
+      "noteNumber": 0,
+      "Pressure": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.PolyPressure",
+    "case": "group_max",
+    "raw": "0xAF4",
+    "decoded": {
+      "messageType": 4,
+      "group": 15,
+      "statusNibble": 10,
+      "channel": 0,
+      "noteNumber": 0,
+      "Pressure": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.PolyPressure",
+    "case": "channel_min",
+    "raw": "0xA04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 10,
+      "channel": 0,
+      "noteNumber": 0,
+      "Pressure": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.PolyPressure",
+    "case": "channel_max",
+    "raw": "0xFA04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 10,
+      "channel": 15,
+      "noteNumber": 0,
+      "Pressure": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.ProgramChangeMessage",
+    "case": "group_min",
+    "raw": "0xC04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 12,
+      "channel": 0,
+      "bankValid": 0,
+      "program": 0,
+      "BankMSB": 0,
+      "BankLSB": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.ProgramChangeMessage",
+    "case": "group_max",
+    "raw": "0xCF4",
+    "decoded": {
+      "messageType": 4,
+      "group": 15,
+      "statusNibble": 12,
+      "channel": 0,
+      "bankValid": 0,
+      "program": 0,
+      "BankMSB": 0,
+      "BankLSB": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.ProgramChangeMessage",
+    "case": "channel_min",
+    "raw": "0xC04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 12,
+      "channel": 0,
+      "bankValid": 0,
+      "program": 0,
+      "BankMSB": 0,
+      "BankLSB": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.ProgramChangeMessage",
+    "case": "channel_max",
+    "raw": "0xFC04",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 12,
+      "channel": 15,
+      "bankValid": 0,
+      "program": 0,
+      "BankMSB": 0,
+      "BankLSB": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.RegisteredControllerRPN",
+    "case": "group_min",
+    "raw": "0x204",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 2,
+      "channel": 0,
+      "Bank": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.RegisteredControllerRPN",
+    "case": "group_max",
+    "raw": "0x2F4",
+    "decoded": {
+      "messageType": 4,
+      "group": 15,
+      "statusNibble": 2,
+      "channel": 0,
+      "Bank": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.RegisteredControllerRPN",
+    "case": "channel_min",
+    "raw": "0x204",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 2,
+      "channel": 0,
+      "Bank": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.RegisteredControllerRPN",
+    "case": "channel_max",
+    "raw": "0xF204",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 2,
+      "channel": 15,
+      "Bank": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.RegisteredPerNoteController",
+    "case": "group_min",
+    "raw": "0x4",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 0,
+      "channel": 0,
+      "noteNumber": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.RegisteredPerNoteController",
+    "case": "group_max",
+    "raw": "0xF4",
+    "decoded": {
+      "messageType": 4,
+      "group": 15,
+      "statusNibble": 0,
+      "channel": 0,
+      "noteNumber": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.RegisteredPerNoteController",
+    "case": "channel_min",
+    "raw": "0x4",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 0,
+      "channel": 0,
+      "noteNumber": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.RegisteredPerNoteController",
+    "case": "channel_max",
+    "raw": "0xF004",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 0,
+      "channel": 15,
+      "noteNumber": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.RelativeAssignableControllerNRPN",
+    "case": "group_min",
+    "raw": "0x504",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 5,
+      "channel": 0,
+      "Bank": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.RelativeAssignableControllerNRPN",
+    "case": "group_max",
+    "raw": "0x5F4",
+    "decoded": {
+      "messageType": 4,
+      "group": 15,
+      "statusNibble": 5,
+      "channel": 0,
+      "Bank": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.RelativeAssignableControllerNRPN",
+    "case": "channel_min",
+    "raw": "0x504",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 5,
+      "channel": 0,
+      "Bank": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.RelativeAssignableControllerNRPN",
+    "case": "channel_max",
+    "raw": "0xF504",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 5,
+      "channel": 15,
+      "Bank": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.RelativeRegisteredControllerRPN",
+    "case": "group_min",
+    "raw": "0x404",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 4,
+      "channel": 0,
+      "Bank": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.RelativeRegisteredControllerRPN",
+    "case": "group_max",
+    "raw": "0x4F4",
+    "decoded": {
+      "messageType": 4,
+      "group": 15,
+      "statusNibble": 4,
+      "channel": 0,
+      "Bank": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.RelativeRegisteredControllerRPN",
+    "case": "channel_min",
+    "raw": "0x404",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 4,
+      "channel": 0,
+      "Bank": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDI20ChannelVoiceMessages.RelativeRegisteredControllerRPN",
+    "case": "channel_max",
+    "raw": "0xF404",
+    "decoded": {
+      "messageType": 4,
+      "group": 0,
+      "statusNibble": 4,
+      "channel": 15,
+      "Bank": 0,
+      "index": 0,
+      "value": 0
+    }
+  },
+  {
+    "name": "MIDIEndpoint.EndofFileMessage",
+    "case": "form_min",
+    "raw": "0x84F",
+    "decoded": {
+      "messageType": 15,
+      "form": 0,
+      "status10": 33
+    }
+  },
+  {
+    "name": "MIDIEndpoint.EndofFileMessage",
+    "case": "form_max",
+    "raw": "0x87F",
+    "decoded": {
+      "messageType": 15,
+      "form": 3,
+      "status10": 33
+    }
+  },
+  {
+    "name": "MIDIEndpoint.FunctionBlockInfoNotification",
+    "case": "form_min",
+    "raw": "0x44F",
+    "decoded": {
+      "messageType": 15,
+      "form": 0,
+      "status10": 17,
+      "Active": 0,
+      "FunctionBlock": 0,
+      "UIHint": 0,
+      "IsMIDI10": 0,
+      "Direction": 0,
+      "FirstGroup": 0,
+      "GroupLength": 0,
+      "MIDICISupport": 0,
+      "MaxSysExStreams": 0
+    }
+  },
+  {
+    "name": "MIDIEndpoint.FunctionBlockInfoNotification",
+    "case": "form_max",
+    "raw": "0x47F",
+    "decoded": {
+      "messageType": 15,
+      "form": 3,
+      "status10": 17,
+      "Active": 0,
+      "FunctionBlock": 0,
+      "UIHint": 0,
+      "IsMIDI10": 0,
+      "Direction": 0,
+      "FirstGroup": 0,
+      "GroupLength": 0,
+      "MIDICISupport": 0,
+      "MaxSysExStreams": 0
+    }
+  },
+  {
+    "name": "MIDIEndpoint.FunctionBlockInfoNotification",
+    "case": "Active_min",
+    "raw": "0x44F",
+    "decoded": {
+      "messageType": 15,
+      "form": 0,
+      "status10": 17,
+      "Active": 0,
+      "FunctionBlock": 0,
+      "UIHint": 0,
+      "IsMIDI10": 0,
+      "Direction": 0,
+      "FirstGroup": 0,
+      "GroupLength": 0,
+      "MIDICISupport": 0,
+      "MaxSysExStreams": 0
+    }
+  },
+  {
+    "name": "MIDIEndpoint.FunctionBlockInfoNotification",
+    "case": "Active_max",
+    "raw": "0x1044F",
+    "decoded": {
+      "messageType": 15,
+      "form": 0,
+      "status10": 17,
+      "Active": 1,
+      "FunctionBlock": 0,
+      "UIHint": 0,
+      "IsMIDI10": 0,
+      "Direction": 0,
+      "FirstGroup": 0,
+      "GroupLength": 0,
+      "MIDICISupport": 0,
+      "MaxSysExStreams": 0
+    }
+  },
+  {
+    "name": "MIDIEndpoint.FunctionBlockNameNotification",
+    "case": "form_min",
+    "raw": "0x48F",
+    "decoded": {
+      "messageType": 15,
+      "form": 0,
+      "status10": 18,
+      "FunctionBlock": 0,
+      "Byte1": 0,
+      "Byte2": 0,
+      "Byte3": 0,
+      "Byte4": 0,
+      "Byte5": 0,
+      "Byte6": 0,
+      "Byte7": 0,
+      "Byte8": 0,
+      "Byte9": 0,
+      "Byte10": 0,
+      "Byte11": 0,
+      "Byte12": 0,
+      "Byte13": 0
+    }
+  },
+  {
+    "name": "MIDIEndpoint.FunctionBlockNameNotification",
+    "case": "form_max",
+    "raw": "0x4BF",
+    "decoded": {
+      "messageType": 15,
+      "form": 3,
+      "status10": 18,
+      "FunctionBlock": 0,
+      "Byte1": 0,
+      "Byte2": 0,
+      "Byte3": 0,
+      "Byte4": 0,
+      "Byte5": 0,
+      "Byte6": 0,
+      "Byte7": 0,
+      "Byte8": 0,
+      "Byte9": 0,
+      "Byte10": 0,
+      "Byte11": 0,
+      "Byte12": 0,
+      "Byte13": 0
+    }
+  },
+  {
+    "name": "MIDIEndpoint.FunctionBlockNameNotification",
+    "case": "FunctionBlock_min",
+    "raw": "0x48F",
+    "decoded": {
+      "messageType": 15,
+      "form": 0,
+      "status10": 18,
+      "FunctionBlock": 0,
+      "Byte1": 0,
+      "Byte2": 0,
+      "Byte3": 0,
+      "Byte4": 0,
+      "Byte5": 0,
+      "Byte6": 0,
+      "Byte7": 0,
+      "Byte8": 0,
+      "Byte9": 0,
+      "Byte10": 0,
+      "Byte11": 0,
+      "Byte12": 0,
+      "Byte13": 0
+    }
+  },
+  {
+    "name": "MIDIEndpoint.FunctionBlockNameNotification",
+    "case": "FunctionBlock_max",
+    "raw": "0xFF048F",
+    "decoded": {
+      "messageType": 15,
+      "form": 0,
+      "status10": 18,
+      "FunctionBlock": 255,
+      "Byte1": 0,
+      "Byte2": 0,
+      "Byte3": 0,
+      "Byte4": 0,
+      "Byte5": 0,
+      "Byte6": 0,
+      "Byte7": 0,
+      "Byte8": 0,
+      "Byte9": 0,
+      "Byte10": 0,
+      "Byte11": 0,
+      "Byte12": 0,
+      "Byte13": 0
+    }
+  },
+  {
+    "name": "MIDIEndpoint.GetFunctionBlockInfo",
+    "case": "form_min",
+    "raw": "0x40F",
+    "decoded": {
+      "messageType": 15,
+      "form": 0,
+      "status10": 16,
+      "FunctionBlock": 0,
+      "RequestingaFunctionBlockNameNotification": 0,
+      "RequestingaFunctionBlockInfoNotification": 0
+    }
+  },
+  {
+    "name": "MIDIEndpoint.GetFunctionBlockInfo",
+    "case": "form_max",
+    "raw": "0x43F",
+    "decoded": {
+      "messageType": 15,
+      "form": 3,
+      "status10": 16,
+      "FunctionBlock": 0,
+      "RequestingaFunctionBlockNameNotification": 0,
+      "RequestingaFunctionBlockInfoNotification": 0
+    }
+  },
+  {
+    "name": "MIDIEndpoint.GetFunctionBlockInfo",
+    "case": "FunctionBlock_min",
+    "raw": "0x40F",
+    "decoded": {
+      "messageType": 15,
+      "form": 0,
+      "status10": 16,
+      "FunctionBlock": 0,
+      "RequestingaFunctionBlockNameNotification": 0,
+      "RequestingaFunctionBlockInfoNotification": 0
+    }
+  },
+  {
+    "name": "MIDIEndpoint.GetFunctionBlockInfo",
+    "case": "FunctionBlock_max",
+    "raw": "0xFF040F",
+    "decoded": {
+      "messageType": 15,
+      "form": 0,
+      "status10": 16,
+      "FunctionBlock": 255,
+      "RequestingaFunctionBlockNameNotification": 0,
+      "RequestingaFunctionBlockInfoNotification": 0
     }
   },
   {
@@ -4505,62 +3785,6 @@
       "status10": 0,
       "UMPVersionMajor": 255,
       "UMPVersionMinor": 0
-    }
-  },
-  {
-    "name": "MIDIEndpoint.MIDIEndpointInfoNotify",
-    "case": "form_min",
-    "raw": "0x4F",
-    "decoded": {
-      "messageType": 15,
-      "form": 0,
-      "status10": 1,
-      "UMPVersionMajor": 0,
-      "UMPVersionMinor": 0,
-      "StaticFunctionBlocks": 0,
-      "NumberofFunctionBlocks": 0
-    }
-  },
-  {
-    "name": "MIDIEndpoint.MIDIEndpointInfoNotify",
-    "case": "form_max",
-    "raw": "0x7F",
-    "decoded": {
-      "messageType": 15,
-      "form": 3,
-      "status10": 1,
-      "UMPVersionMajor": 0,
-      "UMPVersionMinor": 0,
-      "StaticFunctionBlocks": 0,
-      "NumberofFunctionBlocks": 0
-    }
-  },
-  {
-    "name": "MIDIEndpoint.MIDIEndpointInfoNotify",
-    "case": "UMPVersionMajor_min",
-    "raw": "0x4F",
-    "decoded": {
-      "messageType": 15,
-      "form": 0,
-      "status10": 1,
-      "UMPVersionMajor": 0,
-      "UMPVersionMinor": 0,
-      "StaticFunctionBlocks": 0,
-      "NumberofFunctionBlocks": 0
-    }
-  },
-  {
-    "name": "MIDIEndpoint.MIDIEndpointInfoNotify",
-    "case": "UMPVersionMajor_max",
-    "raw": "0xFF004F",
-    "decoded": {
-      "messageType": 15,
-      "form": 0,
-      "status10": 1,
-      "UMPVersionMajor": 255,
-      "UMPVersionMinor": 0,
-      "StaticFunctionBlocks": 0,
-      "NumberofFunctionBlocks": 0
     }
   },
   {
@@ -4645,6 +3869,62 @@
       "SoftwareRevisionLevel2": 0,
       "SoftwareRevisionLevel3": 0,
       "SoftwareRevisionLevel4": 0
+    }
+  },
+  {
+    "name": "MIDIEndpoint.MIDIEndpointInfoNotify",
+    "case": "form_min",
+    "raw": "0x4F",
+    "decoded": {
+      "messageType": 15,
+      "form": 0,
+      "status10": 1,
+      "UMPVersionMajor": 0,
+      "UMPVersionMinor": 0,
+      "StaticFunctionBlocks": 0,
+      "NumberofFunctionBlocks": 0
+    }
+  },
+  {
+    "name": "MIDIEndpoint.MIDIEndpointInfoNotify",
+    "case": "form_max",
+    "raw": "0x7F",
+    "decoded": {
+      "messageType": 15,
+      "form": 3,
+      "status10": 1,
+      "UMPVersionMajor": 0,
+      "UMPVersionMinor": 0,
+      "StaticFunctionBlocks": 0,
+      "NumberofFunctionBlocks": 0
+    }
+  },
+  {
+    "name": "MIDIEndpoint.MIDIEndpointInfoNotify",
+    "case": "UMPVersionMajor_min",
+    "raw": "0x4F",
+    "decoded": {
+      "messageType": 15,
+      "form": 0,
+      "status10": 1,
+      "UMPVersionMajor": 0,
+      "UMPVersionMinor": 0,
+      "StaticFunctionBlocks": 0,
+      "NumberofFunctionBlocks": 0
+    }
+  },
+  {
+    "name": "MIDIEndpoint.MIDIEndpointInfoNotify",
+    "case": "UMPVersionMajor_max",
+    "raw": "0xFF004F",
+    "decoded": {
+      "messageType": 15,
+      "form": 0,
+      "status10": 1,
+      "UMPVersionMajor": 255,
+      "UMPVersionMinor": 0,
+      "StaticFunctionBlocks": 0,
+      "NumberofFunctionBlocks": 0
     }
   },
   {
@@ -4840,47 +4120,23 @@
     }
   },
   {
-    "name": "MIDIEndpoint.StreamConfigurationRequest",
+    "name": "MIDIEndpoint.StartofSequenceMessage",
     "case": "form_min",
-    "raw": "0x14F",
+    "raw": "0x80F",
     "decoded": {
       "messageType": 15,
       "form": 0,
-      "status10": 5,
-      "Protocol": 0
+      "status10": 32
     }
   },
   {
-    "name": "MIDIEndpoint.StreamConfigurationRequest",
+    "name": "MIDIEndpoint.StartofSequenceMessage",
     "case": "form_max",
-    "raw": "0x17F",
+    "raw": "0x83F",
     "decoded": {
       "messageType": 15,
       "form": 3,
-      "status10": 5,
-      "Protocol": 0
-    }
-  },
-  {
-    "name": "MIDIEndpoint.StreamConfigurationRequest",
-    "case": "Protocol_min",
-    "raw": "0x14F",
-    "decoded": {
-      "messageType": 15,
-      "form": 0,
-      "status10": 5,
-      "Protocol": 0
-    }
-  },
-  {
-    "name": "MIDIEndpoint.StreamConfigurationRequest",
-    "case": "Protocol_max",
-    "raw": "0xFF014F",
-    "decoded": {
-      "messageType": 15,
-      "form": 0,
-      "status10": 5,
-      "Protocol": 255
+      "status10": 32
     }
   },
   {
@@ -4928,267 +4184,1011 @@
     }
   },
   {
-    "name": "MIDIEndpoint.GetFunctionBlockInfo",
+    "name": "MIDIEndpoint.StreamConfigurationRequest",
     "case": "form_min",
-    "raw": "0x40F",
+    "raw": "0x14F",
     "decoded": {
       "messageType": 15,
       "form": 0,
-      "status10": 16,
-      "FunctionBlock": 0,
-      "RequestingaFunctionBlockNameNotification": 0,
-      "RequestingaFunctionBlockInfoNotification": 0
+      "status10": 5,
+      "Protocol": 0
     }
   },
   {
-    "name": "MIDIEndpoint.GetFunctionBlockInfo",
+    "name": "MIDIEndpoint.StreamConfigurationRequest",
     "case": "form_max",
-    "raw": "0x43F",
+    "raw": "0x17F",
     "decoded": {
       "messageType": 15,
       "form": 3,
-      "status10": 16,
-      "FunctionBlock": 0,
-      "RequestingaFunctionBlockNameNotification": 0,
-      "RequestingaFunctionBlockInfoNotification": 0
+      "status10": 5,
+      "Protocol": 0
     }
   },
   {
-    "name": "MIDIEndpoint.GetFunctionBlockInfo",
-    "case": "FunctionBlock_min",
-    "raw": "0x40F",
+    "name": "MIDIEndpoint.StreamConfigurationRequest",
+    "case": "Protocol_min",
+    "raw": "0x14F",
     "decoded": {
       "messageType": 15,
       "form": 0,
-      "status10": 16,
-      "FunctionBlock": 0,
-      "RequestingaFunctionBlockNameNotification": 0,
-      "RequestingaFunctionBlockInfoNotification": 0
+      "status10": 5,
+      "Protocol": 0
     }
   },
   {
-    "name": "MIDIEndpoint.GetFunctionBlockInfo",
-    "case": "FunctionBlock_max",
-    "raw": "0xFF040F",
+    "name": "MIDIEndpoint.StreamConfigurationRequest",
+    "case": "Protocol_max",
+    "raw": "0xFF014F",
     "decoded": {
       "messageType": 15,
       "form": 0,
-      "status10": 16,
-      "FunctionBlock": 255,
-      "RequestingaFunctionBlockNameNotification": 0,
-      "RequestingaFunctionBlockInfoNotification": 0
+      "status10": 5,
+      "Protocol": 255
     }
   },
   {
-    "name": "MIDIEndpoint.FunctionBlockInfoNotification",
-    "case": "form_min",
-    "raw": "0x44F",
+    "name": "SysEx.CompleteSystemExclusiveMessageinOnePacket",
+    "case": "group_min",
+    "raw": "0x3",
     "decoded": {
-      "messageType": 15,
-      "form": 0,
-      "status10": 17,
-      "Active": 0,
-      "FunctionBlock": 0,
-      "UIHint": 0,
-      "IsMIDI10": 0,
-      "Direction": 0,
-      "FirstGroup": 0,
-      "GroupLength": 0,
-      "MIDICISupport": 0,
-      "MaxSysExStreams": 0
-    }
-  },
-  {
-    "name": "MIDIEndpoint.FunctionBlockInfoNotification",
-    "case": "form_max",
-    "raw": "0x47F",
-    "decoded": {
-      "messageType": 15,
-      "form": 3,
-      "status10": 17,
-      "Active": 0,
-      "FunctionBlock": 0,
-      "UIHint": 0,
-      "IsMIDI10": 0,
-      "Direction": 0,
-      "FirstGroup": 0,
-      "GroupLength": 0,
-      "MIDICISupport": 0,
-      "MaxSysExStreams": 0
-    }
-  },
-  {
-    "name": "MIDIEndpoint.FunctionBlockInfoNotification",
-    "case": "Active_min",
-    "raw": "0x44F",
-    "decoded": {
-      "messageType": 15,
-      "form": 0,
-      "status10": 17,
-      "Active": 0,
-      "FunctionBlock": 0,
-      "UIHint": 0,
-      "IsMIDI10": 0,
-      "Direction": 0,
-      "FirstGroup": 0,
-      "GroupLength": 0,
-      "MIDICISupport": 0,
-      "MaxSysExStreams": 0
-    }
-  },
-  {
-    "name": "MIDIEndpoint.FunctionBlockInfoNotification",
-    "case": "Active_max",
-    "raw": "0x1044F",
-    "decoded": {
-      "messageType": 15,
-      "form": 0,
-      "status10": 17,
-      "Active": 1,
-      "FunctionBlock": 0,
-      "UIHint": 0,
-      "IsMIDI10": 0,
-      "Direction": 0,
-      "FirstGroup": 0,
-      "GroupLength": 0,
-      "MIDICISupport": 0,
-      "MaxSysExStreams": 0
-    }
-  },
-  {
-    "name": "MIDIEndpoint.FunctionBlockNameNotification",
-    "case": "form_min",
-    "raw": "0x48F",
-    "decoded": {
-      "messageType": 15,
-      "form": 0,
-      "status10": 18,
-      "FunctionBlock": 0,
+      "messageType": 3,
+      "group": 0,
+      "sysexForm": 0,
+      "byteCount": 0,
       "Byte1": 0,
       "Byte2": 0,
       "Byte3": 0,
       "Byte4": 0,
       "Byte5": 0,
-      "Byte6": 0,
-      "Byte7": 0,
-      "Byte8": 0,
-      "Byte9": 0,
-      "Byte10": 0,
-      "Byte11": 0,
-      "Byte12": 0,
-      "Byte13": 0
+      "Byte6": 0
     }
   },
   {
-    "name": "MIDIEndpoint.FunctionBlockNameNotification",
-    "case": "form_max",
-    "raw": "0x4BF",
+    "name": "SysEx.CompleteSystemExclusiveMessageinOnePacket",
+    "case": "group_max",
+    "raw": "0xF3",
     "decoded": {
-      "messageType": 15,
-      "form": 3,
-      "status10": 18,
-      "FunctionBlock": 0,
+      "messageType": 3,
+      "group": 15,
+      "sysexForm": 0,
+      "byteCount": 0,
       "Byte1": 0,
       "Byte2": 0,
       "Byte3": 0,
       "Byte4": 0,
       "Byte5": 0,
-      "Byte6": 0,
-      "Byte7": 0,
-      "Byte8": 0,
-      "Byte9": 0,
-      "Byte10": 0,
-      "Byte11": 0,
-      "Byte12": 0,
-      "Byte13": 0
+      "Byte6": 0
     }
   },
   {
-    "name": "MIDIEndpoint.FunctionBlockNameNotification",
-    "case": "FunctionBlock_min",
-    "raw": "0x48F",
+    "name": "SysEx.CompleteSystemExclusiveMessageinOnePacket",
+    "case": "byteCount_min",
+    "raw": "0x3",
     "decoded": {
-      "messageType": 15,
-      "form": 0,
-      "status10": 18,
-      "FunctionBlock": 0,
+      "messageType": 3,
+      "group": 0,
+      "sysexForm": 0,
+      "byteCount": 0,
       "Byte1": 0,
       "Byte2": 0,
       "Byte3": 0,
       "Byte4": 0,
       "Byte5": 0,
-      "Byte6": 0,
-      "Byte7": 0,
-      "Byte8": 0,
-      "Byte9": 0,
-      "Byte10": 0,
-      "Byte11": 0,
-      "Byte12": 0,
-      "Byte13": 0
+      "Byte6": 0
     }
   },
   {
-    "name": "MIDIEndpoint.FunctionBlockNameNotification",
-    "case": "FunctionBlock_max",
-    "raw": "0xFF048F",
+    "name": "SysEx.CompleteSystemExclusiveMessageinOnePacket",
+    "case": "byteCount_max",
+    "raw": "0xF003",
     "decoded": {
-      "messageType": 15,
-      "form": 0,
-      "status10": 18,
-      "FunctionBlock": 255,
+      "messageType": 3,
+      "group": 0,
+      "sysexForm": 0,
+      "byteCount": 15,
       "Byte1": 0,
       "Byte2": 0,
       "Byte3": 0,
       "Byte4": 0,
       "Byte5": 0,
-      "Byte6": 0,
-      "Byte7": 0,
-      "Byte8": 0,
-      "Byte9": 0,
-      "Byte10": 0,
-      "Byte11": 0,
-      "Byte12": 0,
-      "Byte13": 0
+      "Byte6": 0
     }
   },
   {
-    "name": "MIDIEndpoint.StartofSequenceMessage",
-    "case": "form_min",
-    "raw": "0x80F",
+    "name": "SysEx.SystemExclusiveContinuePacket",
+    "case": "group_min",
+    "raw": "0x203",
     "decoded": {
-      "messageType": 15,
-      "form": 0,
-      "status10": 32
+      "messageType": 3,
+      "group": 0,
+      "sysexForm": 2,
+      "byteCount": 0,
+      "Byte1": 0,
+      "Byte2": 0,
+      "Byte3": 0,
+      "Byte4": 0,
+      "Byte5": 0,
+      "Byte6": 0
     }
   },
   {
-    "name": "MIDIEndpoint.StartofSequenceMessage",
-    "case": "form_max",
-    "raw": "0x83F",
+    "name": "SysEx.SystemExclusiveContinuePacket",
+    "case": "group_max",
+    "raw": "0x2F3",
     "decoded": {
-      "messageType": 15,
-      "form": 3,
-      "status10": 32
+      "messageType": 3,
+      "group": 15,
+      "sysexForm": 2,
+      "byteCount": 0,
+      "Byte1": 0,
+      "Byte2": 0,
+      "Byte3": 0,
+      "Byte4": 0,
+      "Byte5": 0,
+      "Byte6": 0
     }
   },
   {
-    "name": "MIDIEndpoint.EndofFileMessage",
-    "case": "form_min",
-    "raw": "0x84F",
+    "name": "SysEx.SystemExclusiveContinuePacket",
+    "case": "byteCount_min",
+    "raw": "0x203",
     "decoded": {
-      "messageType": 15,
-      "form": 0,
-      "status10": 33
+      "messageType": 3,
+      "group": 0,
+      "sysexForm": 2,
+      "byteCount": 0,
+      "Byte1": 0,
+      "Byte2": 0,
+      "Byte3": 0,
+      "Byte4": 0,
+      "Byte5": 0,
+      "Byte6": 0
     }
   },
   {
-    "name": "MIDIEndpoint.EndofFileMessage",
-    "case": "form_max",
-    "raw": "0x87F",
+    "name": "SysEx.SystemExclusiveContinuePacket",
+    "case": "byteCount_max",
+    "raw": "0xF203",
     "decoded": {
-      "messageType": 15,
-      "form": 3,
-      "status10": 33
+      "messageType": 3,
+      "group": 0,
+      "sysexForm": 2,
+      "byteCount": 15,
+      "Byte1": 0,
+      "Byte2": 0,
+      "Byte3": 0,
+      "Byte4": 0,
+      "Byte5": 0,
+      "Byte6": 0
+    }
+  },
+  {
+    "name": "SysEx.SystemExclusiveEndPacket",
+    "case": "group_min",
+    "raw": "0x303",
+    "decoded": {
+      "messageType": 3,
+      "group": 0,
+      "sysexForm": 3,
+      "byteCount": 0,
+      "Byte1": 0,
+      "Byte2": 0,
+      "Byte3": 0,
+      "Byte4": 0,
+      "Byte5": 0,
+      "Byte6": 0
+    }
+  },
+  {
+    "name": "SysEx.SystemExclusiveEndPacket",
+    "case": "group_max",
+    "raw": "0x3F3",
+    "decoded": {
+      "messageType": 3,
+      "group": 15,
+      "sysexForm": 3,
+      "byteCount": 0,
+      "Byte1": 0,
+      "Byte2": 0,
+      "Byte3": 0,
+      "Byte4": 0,
+      "Byte5": 0,
+      "Byte6": 0
+    }
+  },
+  {
+    "name": "SysEx.SystemExclusiveEndPacket",
+    "case": "byteCount_min",
+    "raw": "0x303",
+    "decoded": {
+      "messageType": 3,
+      "group": 0,
+      "sysexForm": 3,
+      "byteCount": 0,
+      "Byte1": 0,
+      "Byte2": 0,
+      "Byte3": 0,
+      "Byte4": 0,
+      "Byte5": 0,
+      "Byte6": 0
+    }
+  },
+  {
+    "name": "SysEx.SystemExclusiveEndPacket",
+    "case": "byteCount_max",
+    "raw": "0xF303",
+    "decoded": {
+      "messageType": 3,
+      "group": 0,
+      "sysexForm": 3,
+      "byteCount": 15,
+      "Byte1": 0,
+      "Byte2": 0,
+      "Byte3": 0,
+      "Byte4": 0,
+      "Byte5": 0,
+      "Byte6": 0
+    }
+  },
+  {
+    "name": "SysEx.SystemExclusiveStartPacket",
+    "case": "group_min",
+    "raw": "0x103",
+    "decoded": {
+      "messageType": 3,
+      "group": 0,
+      "sysexForm": 1,
+      "byteCount": 0,
+      "Byte1": 0,
+      "Byte2": 0,
+      "Byte3": 0,
+      "Byte4": 0,
+      "Byte5": 0,
+      "Byte6": 0
+    }
+  },
+  {
+    "name": "SysEx.SystemExclusiveStartPacket",
+    "case": "group_max",
+    "raw": "0x1F3",
+    "decoded": {
+      "messageType": 3,
+      "group": 15,
+      "sysexForm": 1,
+      "byteCount": 0,
+      "Byte1": 0,
+      "Byte2": 0,
+      "Byte3": 0,
+      "Byte4": 0,
+      "Byte5": 0,
+      "Byte6": 0
+    }
+  },
+  {
+    "name": "SysEx.SystemExclusiveStartPacket",
+    "case": "byteCount_min",
+    "raw": "0x103",
+    "decoded": {
+      "messageType": 3,
+      "group": 0,
+      "sysexForm": 1,
+      "byteCount": 0,
+      "Byte1": 0,
+      "Byte2": 0,
+      "Byte3": 0,
+      "Byte4": 0,
+      "Byte5": 0,
+      "Byte6": 0
+    }
+  },
+  {
+    "name": "SysEx.SystemExclusiveStartPacket",
+    "case": "byteCount_max",
+    "raw": "0xF103",
+    "decoded": {
+      "messageType": 3,
+      "group": 0,
+      "sysexForm": 1,
+      "byteCount": 15,
+      "Byte1": 0,
+      "Byte2": 0,
+      "Byte3": 0,
+      "Byte4": 0,
+      "Byte5": 0,
+      "Byte6": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.CompleteSystemExclusive8MessageinOnePacket",
+    "case": "group_min",
+    "raw": "0x5",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 0,
+      "byteCount": 0,
+      "streamid": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.CompleteSystemExclusive8MessageinOnePacket",
+    "case": "group_max",
+    "raw": "0xF5",
+    "decoded": {
+      "messageType": 5,
+      "group": 15,
+      "sysex8Form": 0,
+      "byteCount": 0,
+      "streamid": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.CompleteSystemExclusive8MessageinOnePacket",
+    "case": "byteCount_min",
+    "raw": "0x5",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 0,
+      "byteCount": 0,
+      "streamid": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.CompleteSystemExclusive8MessageinOnePacket",
+    "case": "byteCount_max",
+    "raw": "0xF005",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 0,
+      "byteCount": 15,
+      "streamid": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.MixedDataSetHeader",
+    "case": "group_min",
+    "raw": "0x805",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 8,
+      "byteCount": 0,
+      "mdsId": 0,
+      "numberofvalidbytesinthismessagechunk": 0,
+      "numberofchunksinmixeddataset": 0,
+      "numberofthischunk": 0,
+      "manufacturerid": 0,
+      "deviceid": 0,
+      "subid1": 0,
+      "subid2": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.MixedDataSetHeader",
+    "case": "group_max",
+    "raw": "0x8F5",
+    "decoded": {
+      "messageType": 5,
+      "group": 15,
+      "sysex8Form": 8,
+      "byteCount": 0,
+      "mdsId": 0,
+      "numberofvalidbytesinthismessagechunk": 0,
+      "numberofchunksinmixeddataset": 0,
+      "numberofthischunk": 0,
+      "manufacturerid": 0,
+      "deviceid": 0,
+      "subid1": 0,
+      "subid2": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.MixedDataSetHeader",
+    "case": "byteCount_min",
+    "raw": "0x805",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 8,
+      "byteCount": 0,
+      "mdsId": 0,
+      "numberofvalidbytesinthismessagechunk": 0,
+      "numberofchunksinmixeddataset": 0,
+      "numberofthischunk": 0,
+      "manufacturerid": 0,
+      "deviceid": 0,
+      "subid1": 0,
+      "subid2": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.MixedDataSetHeader",
+    "case": "byteCount_max",
+    "raw": "0xF805",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 8,
+      "byteCount": 15,
+      "mdsId": 0,
+      "numberofvalidbytesinthismessagechunk": 0,
+      "numberofchunksinmixeddataset": 0,
+      "numberofthischunk": 0,
+      "manufacturerid": 0,
+      "deviceid": 0,
+      "subid1": 0,
+      "subid2": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.MixedDataSetPayload",
+    "case": "group_min",
+    "raw": "0x905",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 9,
+      "byteCount": 0,
+      "mdsId": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.MixedDataSetPayload",
+    "case": "group_max",
+    "raw": "0x9F5",
+    "decoded": {
+      "messageType": 5,
+      "group": 15,
+      "sysex8Form": 9,
+      "byteCount": 0,
+      "mdsId": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.MixedDataSetPayload",
+    "case": "byteCount_min",
+    "raw": "0x905",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 9,
+      "byteCount": 0,
+      "mdsId": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.MixedDataSetPayload",
+    "case": "byteCount_max",
+    "raw": "0xF905",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 9,
+      "byteCount": 15,
+      "mdsId": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.SystemExclusive8ContinuePacket",
+    "case": "group_min",
+    "raw": "0x205",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 2,
+      "byteCount": 0,
+      "streamid": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.SystemExclusive8ContinuePacket",
+    "case": "group_max",
+    "raw": "0x2F5",
+    "decoded": {
+      "messageType": 5,
+      "group": 15,
+      "sysex8Form": 2,
+      "byteCount": 0,
+      "streamid": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.SystemExclusive8ContinuePacket",
+    "case": "byteCount_min",
+    "raw": "0x205",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 2,
+      "byteCount": 0,
+      "streamid": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.SystemExclusive8ContinuePacket",
+    "case": "byteCount_max",
+    "raw": "0xF205",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 2,
+      "byteCount": 15,
+      "streamid": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.SystemExclusive8StartPacket",
+    "case": "group_min",
+    "raw": "0x105",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 1,
+      "byteCount": 0,
+      "streamid": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.SystemExclusive8StartPacket",
+    "case": "group_max",
+    "raw": "0x1F5",
+    "decoded": {
+      "messageType": 5,
+      "group": 15,
+      "sysex8Form": 1,
+      "byteCount": 0,
+      "streamid": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.SystemExclusive8StartPacket",
+    "case": "byteCount_min",
+    "raw": "0x105",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 1,
+      "byteCount": 0,
+      "streamid": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.SystemExclusive8StartPacket",
+    "case": "byteCount_max",
+    "raw": "0xF105",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 1,
+      "byteCount": 15,
+      "streamid": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.SystemExclusiveEndPacket",
+    "case": "group_min",
+    "raw": "0x305",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 3,
+      "byteCount": 0,
+      "streamid": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.SystemExclusiveEndPacket",
+    "case": "group_max",
+    "raw": "0x3F5",
+    "decoded": {
+      "messageType": 5,
+      "group": 15,
+      "sysex8Form": 3,
+      "byteCount": 0,
+      "streamid": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.SystemExclusiveEndPacket",
+    "case": "byteCount_min",
+    "raw": "0x305",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 3,
+      "byteCount": 0,
+      "streamid": 0
+    }
+  },
+  {
+    "name": "SysEx8andMDS.SystemExclusiveEndPacket",
+    "case": "byteCount_max",
+    "raw": "0xF305",
+    "decoded": {
+      "messageType": 5,
+      "group": 0,
+      "sysex8Form": 3,
+      "byteCount": 15,
+      "streamid": 0
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.ActiveSensing",
+    "case": "group_min",
+    "raw": "0xFE01",
+    "decoded": {
+      "messageType": 1,
+      "group": 0,
+      "statusByte": 254
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.ActiveSensing",
+    "case": "group_max",
+    "raw": "0xFEF1",
+    "decoded": {
+      "messageType": 1,
+      "group": 15,
+      "statusByte": 254
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.Continue",
+    "case": "group_min",
+    "raw": "0xFB01",
+    "decoded": {
+      "messageType": 1,
+      "group": 0,
+      "statusByte": 251
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.Continue",
+    "case": "group_max",
+    "raw": "0xFBF1",
+    "decoded": {
+      "messageType": 1,
+      "group": 15,
+      "statusByte": 251
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.MIDITimeCode",
+    "case": "group_min",
+    "raw": "0xF101",
+    "decoded": {
+      "messageType": 1,
+      "group": 0,
+      "statusByte": 241,
+      "nnndddd": 0
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.MIDITimeCode",
+    "case": "group_max",
+    "raw": "0xF1F1",
+    "decoded": {
+      "messageType": 1,
+      "group": 15,
+      "statusByte": 241,
+      "nnndddd": 0
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.MIDITimeCode",
+    "case": "nnndddd_min",
+    "raw": "0xF101",
+    "decoded": {
+      "messageType": 1,
+      "group": 0,
+      "statusByte": 241,
+      "nnndddd": 0
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.MIDITimeCode",
+    "case": "nnndddd_max",
+    "raw": "0xFEF101",
+    "decoded": {
+      "messageType": 1,
+      "group": 0,
+      "statusByte": 241,
+      "nnndddd": 127
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.Reset",
+    "case": "group_min",
+    "raw": "0xFF01",
+    "decoded": {
+      "messageType": 1,
+      "group": 0,
+      "statusByte": 255
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.Reset",
+    "case": "group_max",
+    "raw": "0xFFF1",
+    "decoded": {
+      "messageType": 1,
+      "group": 15,
+      "statusByte": 255
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.SongPositionPointer",
+    "case": "group_min",
+    "raw": "0xF201",
+    "decoded": {
+      "messageType": 1,
+      "group": 0,
+      "statusByte": 242,
+      "lllllll": 0,
+      "mmmmmmm": 0
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.SongPositionPointer",
+    "case": "group_max",
+    "raw": "0xF2F1",
+    "decoded": {
+      "messageType": 1,
+      "group": 15,
+      "statusByte": 242,
+      "lllllll": 0,
+      "mmmmmmm": 0
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.SongPositionPointer",
+    "case": "lllllll_min",
+    "raw": "0xF201",
+    "decoded": {
+      "messageType": 1,
+      "group": 0,
+      "statusByte": 242,
+      "lllllll": 0,
+      "mmmmmmm": 0
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.SongPositionPointer",
+    "case": "lllllll_max",
+    "raw": "0xFEF201",
+    "decoded": {
+      "messageType": 1,
+      "group": 0,
+      "statusByte": 242,
+      "lllllll": 127,
+      "mmmmmmm": 0
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.SongSelect",
+    "case": "group_min",
+    "raw": "0xF301",
+    "decoded": {
+      "messageType": 1,
+      "group": 0,
+      "statusByte": 243,
+      "sssssss": 0
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.SongSelect",
+    "case": "group_max",
+    "raw": "0xF3F1",
+    "decoded": {
+      "messageType": 1,
+      "group": 15,
+      "statusByte": 243,
+      "sssssss": 0
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.SongSelect",
+    "case": "sssssss_min",
+    "raw": "0xF301",
+    "decoded": {
+      "messageType": 1,
+      "group": 0,
+      "statusByte": 243,
+      "sssssss": 0
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.SongSelect",
+    "case": "sssssss_max",
+    "raw": "0xFEF301",
+    "decoded": {
+      "messageType": 1,
+      "group": 0,
+      "statusByte": 243,
+      "sssssss": 127
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.Start",
+    "case": "group_min",
+    "raw": "0xFA01",
+    "decoded": {
+      "messageType": 1,
+      "group": 0,
+      "statusByte": 250
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.Start",
+    "case": "group_max",
+    "raw": "0xFAF1",
+    "decoded": {
+      "messageType": 1,
+      "group": 15,
+      "statusByte": 250
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.Stop",
+    "case": "group_min",
+    "raw": "0xFC01",
+    "decoded": {
+      "messageType": 1,
+      "group": 0,
+      "statusByte": 252
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.Stop",
+    "case": "group_max",
+    "raw": "0xFCF1",
+    "decoded": {
+      "messageType": 1,
+      "group": 15,
+      "statusByte": 252
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.TimingClock",
+    "case": "group_min",
+    "raw": "0xF801",
+    "decoded": {
+      "messageType": 1,
+      "group": 0,
+      "statusByte": 248
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.TimingClock",
+    "case": "group_max",
+    "raw": "0xF8F1",
+    "decoded": {
+      "messageType": 1,
+      "group": 15,
+      "statusByte": 248
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.TuneRequest",
+    "case": "group_min",
+    "raw": "0xF601",
+    "decoded": {
+      "messageType": 1,
+      "group": 0,
+      "statusByte": 246
+    }
+  },
+  {
+    "name": "SystemRealTimeandSystemCommonMessages.TuneRequest",
+    "case": "group_max",
+    "raw": "0xF6F1",
+    "decoded": {
+      "messageType": 1,
+      "group": 15,
+      "statusByte": 246
+    }
+  },
+  {
+    "name": "UtilityMessages.DeltaClockstamp",
+    "case": "group_min",
+    "raw": "0x400",
+    "decoded": {
+      "messageType": 0,
+      "group": 0,
+      "statusCode": 4
+    }
+  },
+  {
+    "name": "UtilityMessages.DeltaClockstamp",
+    "case": "group_max",
+    "raw": "0x4F0",
+    "decoded": {
+      "messageType": 0,
+      "group": 15,
+      "statusCode": 4
+    }
+  },
+  {
+    "name": "UtilityMessages.DeltaClockstampTicksPerQuarterNote",
+    "case": "group_min",
+    "raw": "0x300",
+    "decoded": {
+      "messageType": 0,
+      "group": 0,
+      "statusCode": 3
+    }
+  },
+  {
+    "name": "UtilityMessages.DeltaClockstampTicksPerQuarterNote",
+    "case": "group_max",
+    "raw": "0x3F0",
+    "decoded": {
+      "messageType": 0,
+      "group": 15,
+      "statusCode": 3
+    }
+  },
+  {
+    "name": "UtilityMessages.JRClock",
+    "case": "group_min",
+    "raw": "0x100",
+    "decoded": {
+      "messageType": 0,
+      "group": 0,
+      "statusCode": 1
+    }
+  },
+  {
+    "name": "UtilityMessages.JRClock",
+    "case": "group_max",
+    "raw": "0x1F0",
+    "decoded": {
+      "messageType": 0,
+      "group": 15,
+      "statusCode": 1
+    }
+  },
+  {
+    "name": "UtilityMessages.JRTimestamp",
+    "case": "group_min",
+    "raw": "0x200",
+    "decoded": {
+      "messageType": 0,
+      "group": 0,
+      "statusCode": 2
+    }
+  },
+  {
+    "name": "UtilityMessages.JRTimestamp",
+    "case": "group_max",
+    "raw": "0x2F0",
+    "decoded": {
+      "messageType": 0,
+      "group": 15,
+      "statusCode": 2
+    }
+  },
+  {
+    "name": "UtilityMessages.NOOP",
+    "case": "group_min",
+    "raw": "0x0",
+    "decoded": {
+      "messageType": 0,
+      "group": 0,
+      "statusCode": 0
+    }
+  },
+  {
+    "name": "UtilityMessages.NOOP",
+    "case": "group_max",
+    "raw": "0xF0",
+    "decoded": {
+      "messageType": 0,
+      "group": 15,
+      "statusCode": 0
     }
   }
 ]

--- a/vectors/golden/ci_statechart.json
+++ b/vectors/golden/ci_statechart.json
@@ -1,19 +1,10 @@
 [
   {
-    "machine": "MIDI-CI.DiscoveryRequest",
+    "machine": "MIDI-CI.ConfirmationNewProtocolEstablishedMessage",
     "sequence": [
-      "Start",
-      "Reply"
+      "Notify"
     ],
     "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.DiscoveryRequest",
-    "sequence": [
-      "Start",
-      "Timeout"
-    ],
-    "expect": "Failed"
   },
   {
     "machine": "MIDI-CI.DiscoveryReply",
@@ -23,6 +14,38 @@
     "expect": "Completed"
   },
   {
+    "machine": "MIDI-CI.DiscoveryRequest",
+    "sequence": [
+      "Start",
+      "Reply"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.DiscoveryRequest",
+    "sequence": [
+      "Start",
+      "Timeout"
+    ],
+    "expect": "Failed"
+  },
+  {
+    "machine": "MIDI-CI.InitiateProtocolNegotiationMessage",
+    "sequence": [
+      "Start",
+      "Reply"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.InitiateProtocolNegotiationMessage",
+    "sequence": [
+      "Start",
+      "Timeout"
+    ],
+    "expect": "Failed"
+  },
+  {
     "machine": "MIDI-CI.InquiryEndpointInformation",
     "sequence": [
       "Start",
@@ -39,7 +62,90 @@
     "expect": "Failed"
   },
   {
-    "machine": "MIDI-CI.ReplytoEndpointInformation",
+    "machine": "MIDI-CI.InquiryGetPropertyData",
+    "sequence": [
+      "Start",
+      "Reply"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.InquiryGetPropertyData",
+    "sequence": [
+      "Start",
+      "ReplyChunk",
+      "Reply"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.InquiryGetPropertyData",
+    "sequence": [
+      "Start",
+      "Timeout"
+    ],
+    "expect": "Failed"
+  },
+  {
+    "machine": "MIDI-CI.InquiryMIDIMessageReport",
+    "sequence": [
+      "Start",
+      "ReplyBegin",
+      "ReplyEnd"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.InquiryMIDIMessageReport",
+    "sequence": [
+      "Start",
+      "Timeout"
+    ],
+    "expect": "Failed"
+  },
+  {
+    "machine": "MIDI-CI.InquiryPropertyExchangeCapabilities",
+    "sequence": [
+      "Start",
+      "Reply"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.InquiryPropertyExchangeCapabilities",
+    "sequence": [
+      "Start",
+      "Timeout"
+    ],
+    "expect": "Failed"
+  },
+  {
+    "machine": "MIDI-CI.InquirySetPropertyData",
+    "sequence": [
+      "Start",
+      "Reply"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.InquirySetPropertyData",
+    "sequence": [
+      "Start",
+      "ReplyChunk",
+      "Reply"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.InquirySetPropertyData",
+    "sequence": [
+      "Start",
+      "Timeout"
+    ],
+    "expect": "Failed"
+  },
+  {
+    "machine": "MIDI-CI.InvalidateMUID",
     "sequence": [
       "Notify"
     ],
@@ -53,288 +159,7 @@
     "expect": "Completed"
   },
   {
-    "machine": "MIDI-CI.InvalidateMUID",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
     "machine": "MIDI-CI.MIDICINAK",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.InitiateProtocolNegotiationMessage",
-    "sequence": [
-      "Start",
-      "Reply"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.InitiateProtocolNegotiationMessage",
-    "sequence": [
-      "Start",
-      "Timeout"
-    ],
-    "expect": "Failed"
-  },
-  {
-    "machine": "MIDI-CI.ReplytoInitiateProtocolNegotiationMessage",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.SetNewProtocolMessage",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.TestNewProtocolInitiatortoResponderMessage",
-    "sequence": [
-      "Start",
-      "Reply"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.TestNewProtocolInitiatortoResponderMessage",
-    "sequence": [
-      "Start",
-      "Timeout"
-    ],
-    "expect": "Failed"
-  },
-  {
-    "machine": "MIDI-CI.TestNewProtocolRespondertoInitiatorMessage",
-    "sequence": [
-      "Start",
-      "Reply"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.TestNewProtocolRespondertoInitiatorMessage",
-    "sequence": [
-      "Start",
-      "Timeout"
-    ],
-    "expect": "Failed"
-  },
-  {
-    "machine": "MIDI-CI.ConfirmationNewProtocolEstablishedMessage",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.ProfileInquiryMessage",
-    "sequence": [
-      "Start",
-      "Reply"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.ProfileInquiryMessage",
-    "sequence": [
-      "Start",
-      "Timeout"
-    ],
-    "expect": "Failed"
-  },
-  {
-    "machine": "MIDI-CI.ReplytoProfileInquiryMessage",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.SetProfileOnMessage",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.SetProfileOffMessage",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.ProfileEnabledReportMessage",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.ProfileDisabledReportMessage",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.ProfileAddedReportMessage",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.ProfileRemovedReportMessage",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.ProfileDetailsInquiryMessage",
-    "sequence": [
-      "Start",
-      "Reply"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.ProfileDetailsInquiryMessage",
-    "sequence": [
-      "Start",
-      "Timeout"
-    ],
-    "expect": "Failed"
-  },
-  {
-    "machine": "MIDI-CI.ReplytoProfileDetailsInquiryMessage",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.ProfileSpecificDatamessage",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.InquiryPropertyExchangeCapabilities",
-    "sequence": [
-      "Start",
-      "Reply"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.InquiryPropertyExchangeCapabilities",
-    "sequence": [
-      "Start",
-      "Timeout"
-    ],
-    "expect": "Failed"
-  },
-  {
-    "machine": "MIDI-CI.ReplytoPropertyExchangeCapabilities",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.InquiryGetPropertyData",
-    "sequence": [
-      "Start",
-      "Reply"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.InquiryGetPropertyData",
-    "sequence": [
-      "Start",
-      "ReplyChunk",
-      "Reply"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.InquiryGetPropertyData",
-    "sequence": [
-      "Start",
-      "Timeout"
-    ],
-    "expect": "Failed"
-  },
-  {
-    "machine": "MIDI-CI.ReplytoGetPropertyData",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.InquirySetPropertyData",
-    "sequence": [
-      "Start",
-      "Reply"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.InquirySetPropertyData",
-    "sequence": [
-      "Start",
-      "ReplyChunk",
-      "Reply"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.InquirySetPropertyData",
-    "sequence": [
-      "Start",
-      "Timeout"
-    ],
-    "expect": "Failed"
-  },
-  {
-    "machine": "MIDI-CI.ReplytoSetPropertyData",
-    "sequence": [
-      "Notify"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.Subscription",
-    "sequence": [
-      "Start",
-      "Reply"
-    ],
-    "expect": "Completed"
-  },
-  {
-    "machine": "MIDI-CI.Subscription",
-    "sequence": [
-      "Start",
-      "Timeout"
-    ],
-    "expect": "Failed"
-  },
-  {
-    "machine": "MIDI-CI.ReplytoSubscription",
     "sequence": [
       "Notify"
     ],
@@ -364,28 +189,92 @@
     "expect": "Failed"
   },
   {
-    "machine": "MIDI-CI.ReplytoProcessInquiryMessage",
+    "machine": "MIDI-CI.ProfileAddedReportMessage",
     "sequence": [
       "Notify"
     ],
     "expect": "Completed"
   },
   {
-    "machine": "MIDI-CI.InquiryMIDIMessageReport",
+    "machine": "MIDI-CI.ProfileDetailsInquiryMessage",
     "sequence": [
       "Start",
-      "ReplyBegin",
-      "ReplyEnd"
+      "Reply"
     ],
     "expect": "Completed"
   },
   {
-    "machine": "MIDI-CI.InquiryMIDIMessageReport",
+    "machine": "MIDI-CI.ProfileDetailsInquiryMessage",
     "sequence": [
       "Start",
       "Timeout"
     ],
     "expect": "Failed"
+  },
+  {
+    "machine": "MIDI-CI.ProfileDisabledReportMessage",
+    "sequence": [
+      "Notify"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.ProfileEnabledReportMessage",
+    "sequence": [
+      "Notify"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.ProfileInquiryMessage",
+    "sequence": [
+      "Start",
+      "Reply"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.ProfileInquiryMessage",
+    "sequence": [
+      "Start",
+      "Timeout"
+    ],
+    "expect": "Failed"
+  },
+  {
+    "machine": "MIDI-CI.ProfileRemovedReportMessage",
+    "sequence": [
+      "Notify"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.ProfileSpecificDatamessage",
+    "sequence": [
+      "Notify"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.ReplytoEndpointInformation",
+    "sequence": [
+      "Notify"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.ReplytoGetPropertyData",
+    "sequence": [
+      "Notify"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.ReplytoInitiateProtocolNegotiationMessage",
+    "sequence": [
+      "Notify"
+    ],
+    "expect": "Completed"
   },
   {
     "machine": "MIDI-CI.ReplytoMIDIMessageReportBegin",
@@ -400,5 +289,116 @@
       "Notify"
     ],
     "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.ReplytoProcessInquiryMessage",
+    "sequence": [
+      "Notify"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.ReplytoProfileDetailsInquiryMessage",
+    "sequence": [
+      "Notify"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.ReplytoProfileInquiryMessage",
+    "sequence": [
+      "Notify"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.ReplytoPropertyExchangeCapabilities",
+    "sequence": [
+      "Notify"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.ReplytoSetPropertyData",
+    "sequence": [
+      "Notify"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.ReplytoSubscription",
+    "sequence": [
+      "Notify"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.SetNewProtocolMessage",
+    "sequence": [
+      "Notify"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.SetProfileOffMessage",
+    "sequence": [
+      "Notify"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.SetProfileOnMessage",
+    "sequence": [
+      "Notify"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.Subscription",
+    "sequence": [
+      "Start",
+      "Reply"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.Subscription",
+    "sequence": [
+      "Start",
+      "Timeout"
+    ],
+    "expect": "Failed"
+  },
+  {
+    "machine": "MIDI-CI.TestNewProtocolInitiatortoResponderMessage",
+    "sequence": [
+      "Start",
+      "Reply"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.TestNewProtocolInitiatortoResponderMessage",
+    "sequence": [
+      "Start",
+      "Timeout"
+    ],
+    "expect": "Failed"
+  },
+  {
+    "machine": "MIDI-CI.TestNewProtocolRespondertoInitiatorMessage",
+    "sequence": [
+      "Start",
+      "Reply"
+    ],
+    "expect": "Completed"
+  },
+  {
+    "machine": "MIDI-CI.TestNewProtocolRespondertoInitiatorMessage",
+    "sequence": [
+      "Start",
+      "Timeout"
+    ],
+    "expect": "Failed"
   }
 ]

--- a/vectors/golden/ump_flex.json
+++ b/vectors/golden/ump_flex.json
@@ -1,166 +1,158 @@
 [
   {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x0",
+    "name": "FlexDataMessages.FlexDataMessages0x1FlexDataMessages0x0",
     "case": "form_0_ch1_g2",
-    "raw": "0x21D",
+    "raw": "0x1021D",
     "decoded": {
       "messageType": 13,
       "channel": 1,
       "group": 2,
       "form": 0,
-      "statusMSB": 0,
+      "statusMSB": 1,
       "statusLSB": 0
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x0",
+    "name": "FlexDataMessages.FlexDataMessages0x1FlexDataMessages0x0",
     "case": "form_1_ch1_g2",
-    "raw": "0x121D",
+    "raw": "0x1121D",
     "decoded": {
       "messageType": 13,
       "channel": 1,
       "group": 2,
       "form": 1,
-      "statusMSB": 0,
+      "statusMSB": 1,
       "statusLSB": 0
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x0",
+    "name": "FlexDataMessages.FlexDataMessages0x1FlexDataMessages0x0",
     "case": "form_2_ch1_g2",
-    "raw": "0x221D",
+    "raw": "0x1221D",
     "decoded": {
       "messageType": 13,
       "channel": 1,
       "group": 2,
       "form": 2,
-      "statusMSB": 0,
+      "statusMSB": 1,
       "statusLSB": 0
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x0",
+    "name": "FlexDataMessages.FlexDataMessages0x1FlexDataMessages0x0",
     "case": "form_3_ch1_g2",
-    "raw": "0x321D",
+    "raw": "0x1321D",
     "decoded": {
       "messageType": 13,
       "channel": 1,
       "group": 2,
       "form": 3,
-      "statusMSB": 0,
+      "statusMSB": 1,
       "statusLSB": 0
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x1",
+    "name": "FlexDataMessages.FlexDataMessages0x1FlexDataMessages0x1",
     "case": "form_0_ch1_g2",
-    "raw": "0x100021D",
+    "raw": "0x101021D",
     "decoded": {
       "messageType": 13,
       "channel": 1,
       "group": 2,
       "form": 0,
-      "statusMSB": 0,
+      "statusMSB": 1,
       "statusLSB": 1
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x1",
+    "name": "FlexDataMessages.FlexDataMessages0x1FlexDataMessages0x1",
     "case": "form_1_ch1_g2",
-    "raw": "0x100121D",
+    "raw": "0x101121D",
     "decoded": {
       "messageType": 13,
       "channel": 1,
       "group": 2,
       "form": 1,
-      "statusMSB": 0,
+      "statusMSB": 1,
       "statusLSB": 1
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x1",
+    "name": "FlexDataMessages.FlexDataMessages0x1FlexDataMessages0x1",
     "case": "form_2_ch1_g2",
-    "raw": "0x100221D",
+    "raw": "0x101221D",
     "decoded": {
       "messageType": 13,
       "channel": 1,
       "group": 2,
       "form": 2,
-      "statusMSB": 0,
+      "statusMSB": 1,
       "statusLSB": 1
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1FlexDataMessages0x1",
+    "name": "FlexDataMessages.FlexDataMessages0x1FlexDataMessages0x1",
     "case": "form_3_ch1_g2",
-    "raw": "0x100321D",
+    "raw": "0x101321D",
     "decoded": {
       "messageType": 13,
       "channel": 1,
       "group": 2,
       "form": 3,
-      "statusMSB": 0,
+      "statusMSB": 1,
       "statusLSB": 1
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1SubdivisionClicks1",
+    "name": "FlexDataMessages.FlexDataMessages0x1FlexDataMessages0x2",
     "case": "form_0_ch1_g2",
-    "raw": "0x200021D",
+    "raw": "0x201021D",
     "decoded": {
       "messageType": 13,
       "channel": 1,
       "group": 2,
       "form": 0,
-      "statusMSB": 0,
-      "statusLSB": 2,
-      "SubdivisionClicks1": 0,
-      "SubdivisionClicks2": 0
+      "statusMSB": 1,
+      "statusLSB": 2
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1SubdivisionClicks1",
+    "name": "FlexDataMessages.FlexDataMessages0x1FlexDataMessages0x2",
     "case": "form_1_ch1_g2",
-    "raw": "0x200121D",
+    "raw": "0x201121D",
     "decoded": {
       "messageType": 13,
       "channel": 1,
       "group": 2,
       "form": 1,
-      "statusMSB": 0,
-      "statusLSB": 2,
-      "SubdivisionClicks1": 0,
-      "SubdivisionClicks2": 0
+      "statusMSB": 1,
+      "statusLSB": 2
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1SubdivisionClicks1",
+    "name": "FlexDataMessages.FlexDataMessages0x1FlexDataMessages0x2",
     "case": "form_2_ch1_g2",
-    "raw": "0x200221D",
+    "raw": "0x201221D",
     "decoded": {
       "messageType": 13,
       "channel": 1,
       "group": 2,
       "form": 2,
-      "statusMSB": 0,
-      "statusLSB": 2,
-      "SubdivisionClicks1": 0,
-      "SubdivisionClicks2": 0
+      "statusMSB": 1,
+      "statusLSB": 2
     }
   },
   {
-    "name": "FlexDataMessages.SubdivisionClicks1SubdivisionClicks1",
+    "name": "FlexDataMessages.FlexDataMessages0x1FlexDataMessages0x2",
     "case": "form_3_ch1_g2",
-    "raw": "0x200321D",
+    "raw": "0x201321D",
     "decoded": {
       "messageType": 13,
       "channel": 1,
       "group": 2,
       "form": 3,
-      "statusMSB": 0,
-      "statusLSB": 2,
-      "SubdivisionClicks1": 0,
-      "SubdivisionClicks2": 0
+      "statusMSB": 1,
+      "statusLSB": 2
     }
   }
 ]


### PR DESCRIPTION
## Summary
- capture repository commit hash and derive enums in static extractor
- regenerate deterministic `midi2.json` including enum definitions and commit metadata

## Testing
- `node scripts/extract-static.js`
- `node scripts/verify-contract.js`

------
https://chatgpt.com/codex/tasks/task_b_6898368c6a148333b1e48d765d5f78be