### PR TITLE
Ensure UMP decoder handles unknown types

### DIFF
--- a/scripts/codegen-swift-dispatch.js
+++ b/scripts/codegen-swift-dispatch.js
@@ -142,6 +142,10 @@ function main(){
       // Default: fall back to best-effort ordered attempts
       entries.push(`        case ${key}:\n${genTryList(msgs, container)}`);
     }
+    if (!keys.includes('any')) {
+      // ensure switch is exhaustive
+      entries.push('        default:\n            return nil');
+    }
     const getMt = container==='UMP32' ? `let mt = getBits32(ump.raw, offset: 0, width: 4)`
                : container==='UMP64' ? `let mt = getBits(ump.raw, offset: 0, width: 4)`
                : `let mt = getBits128(ump.lo, ump.hi, offset: 0, width: 4)`;

--- a/swift/Midi2Swift/Sources/UMP/Generated/UMPAnyMessage.swift
+++ b/swift/Midi2Swift/Sources/UMP/Generated/UMPAnyMessage.swift
@@ -132,6 +132,8 @@ let mt = getBits32(ump.raw, offset: 0, width: 4)
         if (getBits32(ump.raw, offset: 0, width: 4) == 2 && getBits32(ump.raw, offset: 8, width: 4) == 10) { if let v = MIDI10ChannelVoiceMessagesPolyPressure.decode(ump) { return .MIDI10ChannelVoiceMessagesPolyPressure(v) } }
         if (getBits32(ump.raw, offset: 0, width: 4) == 2 && getBits32(ump.raw, offset: 8, width: 4) == 12) { if let v = MIDI10ChannelVoiceMessagesProgramChangeMessage.decode(ump) { return .MIDI10ChannelVoiceMessagesProgramChangeMessage(v) } }
         return nil
+        default:
+            return nil
         }
     }
     public static func decode(_ ump: UMP64) -> UMPAnyMessage? {
@@ -165,6 +167,8 @@ let mt = getBits(ump.raw, offset: 0, width: 4)
         if (getBits(ump.raw, offset: 0, width: 4) == 4 && getBits(ump.raw, offset: 8, width: 4) == 5) { if let v = MIDI20ChannelVoiceMessagesRelativeAssignableControllerNRPN.decode(ump) { return .MIDI20ChannelVoiceMessagesRelativeAssignableControllerNRPN(v) } }
         if (getBits(ump.raw, offset: 0, width: 4) == 4 && getBits(ump.raw, offset: 8, width: 4) == 4) { if let v = MIDI20ChannelVoiceMessagesRelativeRegisteredControllerRPN.decode(ump) { return .MIDI20ChannelVoiceMessagesRelativeRegisteredControllerRPN(v) } }
         return nil
+        default:
+            return nil
         }
     }
     public static func decode(_ ump: UMP128) -> UMPAnyMessage? {
@@ -255,6 +259,8 @@ let mt = getBits128(ump.lo, ump.hi, offset: 0, width: 4)
         if (getBits128(ump.lo, ump.hi, offset: 0, width: 4) == 15 && getBits128(ump.lo, ump.hi, offset: 6, width: 10) == 6) { if let v = MIDIEndpointStreamConfigurationNotify.decode(ump) { return .MIDIEndpointStreamConfigurationNotify(v) } }
         if (getBits128(ump.lo, ump.hi, offset: 0, width: 4) == 15 && getBits128(ump.lo, ump.hi, offset: 6, width: 10) == 5) { if let v = MIDIEndpointStreamConfigurationRequest.decode(ump) { return .MIDIEndpointStreamConfigurationRequest(v) } }
         return nil
+        default:
+            return nil
         }
     }
 }

--- a/swift/Midi2Swift/Tests/UMPTests/AutoVectorDecodeSmokeTests.swift
+++ b/swift/Midi2Swift/Tests/UMPTests/AutoVectorDecodeSmokeTests.swift
@@ -26,11 +26,10 @@ final class AutoVectorDecodeSmokeTests: XCTestCase {
         try decode64(groups, name: "SysEx.System Exclusive End Packet") { raw in
             XCTAssertNotNil(SysExSystemExclusiveEndPacket.decode(.init(raw: raw)))
         }
-        try decode64(groups, name: "SysEx8 and MDS.System Exclusive 8 Start Packet") { raw in
-            XCTAssertNotNil(SysEx8andMDSSystemExclusive8StartPacket.decode(.init(raw: raw)))
-        }
-
         // UMP128
+        try decode128(groups, name: "SysEx8 and MDS.System Exclusive 8 Start Packet") { lo, hi in
+            XCTAssertNotNil(SysEx8andMDSSystemExclusive8StartPacket.decode(.init(lo: lo, hi: hi)))
+        }
         try decode128(groups, name: "MIDI Endpoint.MIDI Endpoint Info Notify") { lo, hi in
             XCTAssertNotNil(MIDIEndpointMIDIEndpointInfoNotify.decode(.init(lo: lo, hi: hi)))
         }

--- a/vectors/golden/ump_sysex8.json
+++ b/vectors/golden/ump_sysex8.json
@@ -2,7 +2,7 @@
   {
     "name": "SysEx8andMDS.MixedDataSetHeader",
     "case": "simple",
-    "raw": "0x3040102001012400001000102012805",
+    "raw": "0x03040102001012340001000102012805",
     "decoded": {
       "group": 0,
       "bytecount": 2,


### PR DESCRIPTION
## Summary
- add default case generation for UMP decoders to return `nil` for unknown message types
- fix SysEx8 MixedDataSetHeader golden vector and adjust smoke tests for 128-bit SysEx8 start packet

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68988e8633f883338960be303e123027